### PR TITLE
Add bracketed access to ephemeris, deal with cusp failures, improves tests.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -9,14 +9,19 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8']
+        cabal: ['3.0']
+        os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-haskell@v1
       with:
-        ghc-version: '8.8.2'
-        cabal-version: '3.0'
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
 
     - name: Cache
       uses: actions/cache@v1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,10 +2,12 @@
 
 ## v0.2.0.0
 
-* Introduces `withEphemerides` for bracketed access to the ephemeris file.
+* Introduces `withEphemerides` for bracketed access to the ephemeris directory.
 * Changes the signature of `calculateCusps` to return a `Left` value if the underlying library
   is unable to calculate the cusps.
-* Improves test coverage.
+* Introduces "monadic" versions of the calculations that work with instances of `MonadFail`:
+  `calculateCuspsM` and `calculateCoordinatesM`
+* Improves test coverage with property testing.
 
 ## v0.1.0.0 - 0.1.0.2(2020-08-12)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,14 @@
 # Changelog for swiss-ephemeris
 
-## v0.1.0.0 (2020-08-12)
+## v0.2.0.0
+
+* Introduces `withEphemerides` for bracketed access to the ephemeris file.
+* Introduces "prime" versions of the functions to work on a `MonadFail`.
+* Changes the signature of `calculateCusps` to fail if the underlying library
+  is unable to calculate the cusps.
+* Improves test coverage.
+
+## v0.1.0.0 - 0.1.0.2(2020-08-12)
 
 * Bundles the C code for v2.09.01 of [Swiss
   Ephemerides](https://www.astro.com/swisseph/swephinfo_e.htm) -- refer to that

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,8 +3,7 @@
 ## v0.2.0.0
 
 * Introduces `withEphemerides` for bracketed access to the ephemeris file.
-* Introduces "prime" versions of the functions to work on a `MonadFail`.
-* Changes the signature of `calculateCusps` to fail if the underlying library
+* Changes the signature of `calculateCusps` to return a `Left` value if the underlying library
   is unable to calculate the cusps.
 * Improves test coverage.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ import SwissEphemeris
 main :: IO
 main = do 
   -- location of your ephemeris directory, must be absolute. We bundle a sample one in `swedist`.
-  setEphemeridesPath "/Users/luis/code/swiss-ephemeris/swedist/sweph_18"
+  setEphemeridesPath "./swedist/sweph_18"
 
   let time = julianDay 1989 1 6 0.0
   let place = defaultCoords{lat = 14.0839053, lng = -87.2750137}
@@ -29,8 +29,11 @@ main = do
 
 Should print the latitude and longitude (plus some velocities) for all planets, and the cusps and other major angles.
 
-To see actual results, check out the tests. For some more advanced examples, see `swetest.c` and `swemini.c` in the `csrc` directory: they're the test/example 
+To see actual results and more advanced usage, check out the tests. For some more advanced examples, see `swetest.c` and `swemini.c` in the `csrc` directory: they're the test/example 
 programs provided by the original authors.
+
+Both calculation functions will return `Either String a` (with `a` being the actual calculation,) in case an error is raised
+by the underlying library. If you'd prefer a `MonadFail` version, check out `calculateCuspsM` and `calculateCoordinatesM`.
 
 ## Notes
 
@@ -64,19 +67,7 @@ For a full explanation of the files available, see the [Description of the Ephem
 interest is the [comparison between the Swiss Ephemeris and the raw NASA JPL
 data](https://www.astro.com/swisseph/swisseph.htm#_Toc46391741).
 
-### CI Build
-
-You'll notice that I build against Github's [`macos-latest`](https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources) VM. This mirrors my development machine -- I noticed that the tests suffer a precision degradation when run on ubuntu, e.g.:
-
-```haskell
- expected: Right (Coordinates {lng = 285.64724200024165, lat = -8.254238068673002e-5, distance = 0.983344884137739, lngSpeed = 1.0196526213625938, latSpeed = 1.4968387810319695e-5, distSpeed = 1.734078975098347e-5})
-  but got: Right (Coordinates {lng = 285.6472420002416, lat = -8.254238068996486e-5, distance = 0.9833448841377388, lngSpeed = 1.0196526213625938, latSpeed = 1.496838781028185e-5, distSpeed = 1.7340789750982604e-5})
-```
-
-Not sure if it's due to the C compiler in the GH environment, or if it's something on the actual software; however, caveat emptor!
-
 ## Contributing
 
 I've only made available the types and functions that are useful for my own, traditional, horoscope calculations.
 Feel free to add more! See the [astro.com documentation](https://www.astro.com/swisseph/swisseph.htm) for ideas.
-

--- a/package.yaml
+++ b/package.yaml
@@ -70,5 +70,6 @@ tests:
     - swiss-ephemeris
     - hspec >= 2.7 && < 2.8
     - directory >= 1.3 && < 1.4
+    - QuickCheck >= 2.12 && <= 2.14
     build-tools:
     - hspec-discover >= 2.7 && < 2.8

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                swiss-ephemeris
-version:             0.1.0.2
+version:             0.2.0.0
 github:              "lfborjas/swiss-ephemeris"
 license:             GPL-2
 author:              "Luis Borjas Reyes"

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -86,4 +86,4 @@ foreign import ccall unsafe "swephexp.h swe_houses"
                  -> CInt -- house system (see .hs version of this file)
                  -> Ptr CDouble -- cusps, 13 doubles (or 37 in system G)
                  -> Ptr CDouble -- ascmc, 10 doubles
-                 -> IO ()
+                 -> CInt

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -57,7 +57,7 @@ data HouseSystem = Placidus
                  | Campanus
                  | Equal
                  | WholeSign
-                 deriving (Show, Eq, Ord, Generic)
+                 deriving (Show, Eq, Ord, Enum, Generic)
 
 type JulianTime = Double
 
@@ -201,7 +201,7 @@ calculateCoordinates time planet =
                 result <- peekArray 6 coords
                 return $ Right $ fromList $ map realToFrac result
 
--- | MonadFail version of `calculateCoordinates`, in case you don't particularly care
+-- | 'MonadFail' version of `calculateCoordinates`, in case you don't particularly care
 -- about the error message (since it's likely to be due to misconfigured ephe files)
 -- and want it to play nice with other `MonadFail` computations.
 calculateCoordinatesM :: MonadFail m => JulianTime -> Planet -> m Coordinates
@@ -233,9 +233,9 @@ calculateCusps time loc sys = unsafePerformIO $ allocaArray 13 $ \cusps ->
                              (fromCuspsList $ map realToFrac $ cuspsL) 
                              (fromAnglesList $ map realToFrac $ anglesL)
 
--- | MonadFail version of `calculateCusps`, in case you don't particularly care about
+-- | 'MonadFail' version of `calculateCusps`, in case you don't particularly care about
 -- the error message (there's only one error scenario currently: inability to 
--- determine cusps, in coordinates not contemplated by the given house system.
+-- determine cusps, in coordinates not contemplated by the given house system.)
 calculateCuspsM :: MonadFail m => JulianTime -> Coordinates -> HouseSystem -> m CuspsCalculation
 calculateCuspsM time loc sys = do
   let calcs = calculateCusps time loc sys

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -11,6 +11,7 @@ module SwissEphemeris (
 ,   defaultCoordinates
 ,   setEphemeridesPath
 ,   closeEphemerides
+,   withEphemerides
 ,   julianDay
 ,   calculateCoordinates
 ,   calculateCusps
@@ -24,6 +25,7 @@ import           System.IO.Unsafe
 import           Foreign.C.Types
 import           Foreign.C.String
 import           Data.Char                      ( ord )
+import Control.Exception (bracket_)
 
 data Planet = Sun
             | Moon
@@ -155,6 +157,14 @@ setEphemeridesPath path =
 -- library.
 closeEphemerides :: IO ()
 closeEphemerides = c_swe_close
+
+-- | Run a computation with a given ephemerides path open, and then close it. 
+-- Note that the computation does _not_ receive the ephemerides, 
+-- in keeping with the underlying library's side-effectful conventions.
+withEphemerides :: FilePath -> (IO a) -> IO a
+withEphemerides ephemeridesPath =
+  bracket_ (setEphemeridesPath ephemeridesPath)
+           (closeEphemerides)
 
 -- | Given year, month and day as @Int@ and a time as @Double@, return
 -- a single floating point number representing absolute Julian Time.

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -153,10 +153,7 @@ planetNumber p = PlanetNumber $ CInt y
 -- if the environment variable `SE_EPHE_PATH` is set, it overrides this function.
 setEphemeridesPath :: String -> IO ()
 setEphemeridesPath path =
-    -- note, using the *CA* variants of String functions, since the swe
-    -- code seems to be ignorant of UTF8:
-    -- http://hackage.haskell.org/package/base-4.14.0.0/docs/Foreign-C-String.html#g:3
-    withCAString path $ \ephePath -> c_swe_set_ephe_path ephePath
+    withCString path $ \ephePath -> c_swe_set_ephe_path ephePath
 
 -- | Explicitly release all "cache" pointers and open files obtained by the C
 -- library.

--- a/swiss-ephemeris.cabal
+++ b/swiss-ephemeris.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fc34c59af8a95680722a717ac598f19acce37dc5ba52a89672cdded3e5489c51
+-- hash: d32207eeeee07aee4c95a2b99ee554496ccf865fab743d46a306e2df22e9e436
 
 name:           swiss-ephemeris
-version:        0.1.0.2
+version:        0.2.0.0
 synopsis:       Haskell bindings for the Swiss Ephemeris C library
 description:    Please see the README on GitHub at <https://github.com/lfborjas/swiss-ephemeris#readme>
 category:       Data, Astrology

--- a/swiss-ephemeris.cabal
+++ b/swiss-ephemeris.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a9d3b6dd4f5d100849c990835c883a7b39d22e26208c13ad2dbf95674d89600f
+-- hash: fc34c59af8a95680722a717ac598f19acce37dc5ba52a89672cdded3e5489c51
 
 name:           swiss-ephemeris
 version:        0.1.0.2
@@ -77,7 +77,8 @@ test-suite swiss-ephemeris-test
   build-tool-depends:
       hspec-discover:hspec-discover >=2.7 && <2.8
   build-depends:
-      base >=4.7 && <4.14
+      QuickCheck >=2.12 && <=2.14
+    , base >=4.7 && <4.14
     , directory >=1.3 && <1.4
     , hspec >=2.7 && <2.8
     , swiss-ephemeris

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -129,7 +129,7 @@ spec = do
                 }
 
       let calcs = calculateCusps time place Placidus
-      calcs `shouldBe` expectedCalculations
+      calcs `compareCalculations` expectedCalculations
 
 {- For reference, here's the official test output from swetest.c as retrieved from the swetest page:
 https://www.astro.com/cgi/swetest.cgi?b=6.1.1989&n=1&s=1&p=p&e=-eswe&f=PlbRS&arg=
@@ -191,3 +191,28 @@ compareCoords (Right a) (Right b) = do
    latSpeed a `shouldBeApprox` latSpeed b
    distSpeed a `shouldBeApprox` distSpeed b
 compareCoords _ _ = expectationFailure "Expected coordinates, got a failure."
+
+compareCalculations :: CuspsCalculation -> CuspsCalculation -> Expectation
+compareCalculations (CuspsCalculation housesA anglesA) (CuspsCalculation housesB anglesB) = do
+  i housesA `shouldBeApprox` i housesB
+  ii housesA `shouldBeApprox` ii housesB
+  iii housesA `shouldBeApprox` iii housesB
+  iv housesA `shouldBeApprox` iv housesB
+  v housesA `shouldBeApprox` v housesB
+  vi housesA `shouldBeApprox` vi housesB
+  vii housesA `shouldBeApprox` vii housesB
+  viii housesA `shouldBeApprox` viii housesB
+  ix housesA `shouldBeApprox` ix housesB
+  x housesA `shouldBeApprox` x housesB
+  xi housesA `shouldBeApprox` xi housesB
+  xii housesA `shouldBeApprox` xii housesB
+
+  -- angles:
+  ascendant anglesA `shouldBeApprox` ascendant anglesB
+  mc anglesA `shouldBeApprox` mc anglesB
+  armc anglesA `shouldBeApprox` armc anglesB
+  vertex anglesA `shouldBeApprox` vertex anglesB
+  equatorialAscendant anglesA `shouldBeApprox` equatorialAscendant anglesB
+  coAscendantKoch anglesA `shouldBeApprox` coAscendantKoch anglesB
+  coAscendantMunkasey anglesA `shouldBeApprox` coAscendantMunkasey anglesB
+  polarAscendant anglesA `shouldBeApprox` polarAscendant anglesB

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -65,7 +65,7 @@ spec = do
       let expectedCoords = Left "SwissEph file 'seas_18.se1' not found in PATH '.:/users/ephe2/:/users/ephe/'"
       coords `shouldBe` expectedCoords
 
-  around_ (withEphemerides (unsafePerformIO $ makeAbsolute  "./swedist/sweph_18/" )) $ do
+  around_ (withEphemerides (unsafePerformIO $ makeAbsolute  "./swedist/sweph_18" )) $ do
     describe "setEphemeridesPath" $ do
       it "calculates more precise coordinates for the Sun if an ephemeris file is set" $ do
         let time = julianDay 1989 1 6 0.0

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -62,7 +62,7 @@ spec = do
       let expectedCoords = Left "SwissEph file 'seas_18.se1' not found in PATH '.:/users/ephe2/:/users/ephe/'"
       coords `shouldBe` expectedCoords
 
-  around_ (withEphemerides "./swedist/sweph_18") $ do
+  around_ (withEphemerides "./swedist/sweph_18/") $ do
     describe "setEphemeridesPath" $ do
       it "calculates more precise coordinates for the Sun if an ephemeris file is set" $ do
         let time = julianDay 1989 1 6 0.0


### PR DESCRIPTION
* Introduces `withEphemerides` for bracketed access to the ephemeris directory.
* Changes the signature of `calculateCusps` to return a `Left` value if the underlying library
  is unable to calculate the cusps.
* Introduces "monadic" versions of the calculations that work with instances of `MonadFail`:
  `calculateCuspsM` and `calculateCoordinatesM`
* Improves test coverage with property testing.