### PR TITLE
Fixes memory leak caused by error string.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         ghc: ['8.6.5', '8.8.3']
         cabal: ['3.2']

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,7 +15,7 @@ jobs:
         cabal: ['3.2']
         os: [ubuntu-latest, macos-latest]
     env:
-      CONFIG: "--enable-tests --enable-benchmarks --test-show-details=always"
+      CONFIG: "--enable-tests --enable-benchmarks --test-show-details=direct"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-haskell@v1.1.2

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.6.5', '8.8.3']
+        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.3']
         cabal: ['3.2']
         os: [ubuntu-latest, macos-latest]
     env:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,7 +16,7 @@ jobs:
         cabal: ['3.2']
         os: [ubuntu-latest, macos-latest]
     env:
-      CONFIG: "--enable-tests --enable-benchmarks --test-show-details=direct"
+      CONFIG: "--enable-tests --enable-benchmarks --test-show-details=streaming"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-haskell@v1.1.2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Changelog for swiss-ephemeris
 
+## v0.3.1.0
+
+* Fixes occasional segmentation fault (caught most often in the more memory-strapped CI server than in my computer,)
+  caused by using [`alloca`](https://hackage.haskell.org/package/base-4.14.0.0/docs/Foreign-Marshal-Alloc.html#v:alloca) for the error string and, when no error string was populated, ending with undefined
+  behavior. Now we explicitly allocate the 256 `char`s that the documentation and C sources recommend, which seems to be always
+  freed by Haskell, vs. leaving a hole somewhere when the underlying library fails to terminate the string.
+
 ## v0.3.0.0
 
 **Breaking fixes to `calculateCusps` and `calculateCoordinates`**

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                swiss-ephemeris
-version:             0.3.0.0
+version:             0.3.1.0
 github:              "lfborjas/swiss-ephemeris"
 license:             GPL-2
 author:              "Luis Borjas Reyes"

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -65,12 +65,12 @@ type JulianTime = Double
 
 data Coordinates = Coordinates
   {
-    lng :: Double
-  , lat :: Double
-  , distance :: Double
-  , lngSpeed :: Double
-  , latSpeed :: Double
-  , distSpeed :: Double
+    lng :: !Double
+  , lat :: !Double
+  , distance :: !Double
+  , lngSpeed :: !Double
+  , latSpeed :: !Double
+  , distSpeed :: !Double
   } deriving (Show, Eq, Ord, Generic)
 
 -- | Default coordinates with all zeros -- when you don't care about/know the velocities,
@@ -214,7 +214,7 @@ julianDay year month day hour = realToFrac $ c_swe_julday y m d h gregorian
 -- will likely result in a segmentation fault down the line!!
 calculateCoordinates :: JulianTime -> Planet -> IO (Either String Coordinates)
 calculateCoordinates time planet =
-    allocaArray 6 $ \coords -> alloca $ \errorP -> do
+    allocaArray 6 $ \coords -> allocaArray 256 $ \errorP -> do
         iflgret <- c_swe_calc (realToFrac time)
                               (planetNumber planet)
                               speed
@@ -227,7 +227,6 @@ calculateCoordinates time planet =
                           pure $ "Unable to calculate position; NULL error from swiss ephemeris."
                         else
                           peekCAString errorP
-                 
                 return $ Left msg
             else do
                 result <- peekArray 6 coords

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -65,12 +65,12 @@ type JulianTime = Double
 
 data Coordinates = Coordinates
   {
-    lng :: !Double
-  , lat :: !Double
-  , distance :: !Double
-  , lngSpeed :: !Double
-  , latSpeed :: !Double
-  , distSpeed :: !Double
+    lng :: Double
+  , lat :: Double
+  , distance :: Double
+  , lngSpeed :: Double
+  , latSpeed :: Double
+  , distSpeed :: Double
   } deriving (Show, Eq, Ord, Generic)
 
 -- | Default coordinates with all zeros -- when you don't care about/know the velocities,
@@ -209,9 +209,6 @@ julianDay year month day hour = realToFrac $ c_swe_julday y m d h gregorian
 -- if available in the ephemeris, or an error.
 -- This function is in IO because it _may_ allocate memory/read data beyond
 -- its scope, when using ephemeris data. 
--- Call it with `withEphemerides` or `withoutEphemerides`.
--- Failing to call `closeEphemerides` at some point after calling this function
--- will likely result in a segmentation fault down the line!!
 calculateCoordinates :: JulianTime -> Planet -> IO (Either String Coordinates)
 calculateCoordinates time planet =
     allocaArray 6 $ \coords -> allocaArray 256 $ \errorP -> do
@@ -223,10 +220,7 @@ calculateCoordinates time planet =
 
         if unCalcFlag iflgret < 0
             then do
-                msg <- if errorP == nullPtr then 
-                          pure $ "Unable to calculate position; NULL error from swiss ephemeris."
-                        else
-                          peekCAString errorP
+                msg <- peekCAString errorP
                 return $ Left msg
             else do
                 result <- peekArray 6 coords
@@ -244,9 +238,6 @@ calculateCusps = calculateCuspsLenient
 -- and other edge cases, the calculation returns cusps in the `Porphyrius` system.
 -- This function is in IO because it _may_ allocate memory/read data beyond
 -- its scope, when using ephemeris data. 
--- Call it with `withEphemerides` or `withoutEphemerides`.
--- Failing to call `closeEphemerides` at some point after calling this function
--- will likely result in a segmentation fault!!
 calculateCuspsLenient :: JulianTime -> Coordinates -> HouseSystem -> IO CuspsCalculation
 calculateCuspsLenient time loc sys = allocaArray 13 $ \cusps ->
     allocaArray 10 $ \ascmc -> do

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -270,6 +270,6 @@ calculateCuspsStrict :: JulianTime -> Coordinates -> HouseSystem -> IO (Either S
 calculateCuspsStrict time loc sys = do
   calcs@(CuspsCalculation _ _ sys') <- calculateCuspsLenient time loc sys
   if sys' /= sys then
-    pure $ Left $ "Unable to calculate cusps in the requested house system (used " ++ (show sys') ++ "instead.)"
+    pure $ Left $ "Unable to calculate cusps in the requested house system (used " ++ (show sys') ++ " instead.)"
   else
     pure $ Right calcs

--- a/swiss-ephemeris.cabal
+++ b/swiss-ephemeris.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 87ffdea3bb85146020e6e28105509ccdfb6b80382fa9e7380aebfe9512b672c1
+-- hash: 93624daf4532a29f759103fcb83b46a0d23ea8a3805212214b2812fbfce1e723
 
 name:           swiss-ephemeris
-version:        0.3.0.0
+version:        0.3.1.0
 synopsis:       Haskell bindings for the Swiss Ephemeris C library
 description:    Please see the README on GitHub at <https://github.com/lfborjas/swiss-ephemeris#readme>
 category:       Data, Astrology

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -20,36 +20,36 @@ ephePath :: FilePath
 ephePath = "./swedist/sweph_18"
 
 debug :: Applicative f => String -> f ()
-debug = traceM
---debug _ = pure ()
+--debug = traceM
+debug _ = pure ()
 --debug _ = traceM "Exercising stdout"
 
 spec :: Spec
 spec = do
   around_ ( withoutEphemerides ) $ do
-    describe "calculateCoordinates" $ do
-      it "calculates coordinates for the Sun for a specific day" $ do
-        let time = julianDay 1989 1 6 0.0
-            expectedCoords =
-              Right $
-                Coordinates
-                  { lng = 285.64723120365153,
-                    lat = -8.664716530514133e-5,
-                    distance = 0.9833448914987339,
-                    lngSpeed = 1.0196505771457982,
-                    latSpeed = 1.4550248863443192e-5,
-                    distSpeed = 1.7364210462433863e-5
-                  }
-        coords <- calculateCoordinates time Sun
-        debug $ "Getting coordinates for the sun: " ++ (show coords)
-        coords `compareCoords` expectedCoords
+    -- describe "calculateCoordinates" $ do
+    --   it "calculates coordinates for the Sun for a specific day" $ do
+    --     let time = julianDay 1989 1 6 0.0
+    --         expectedCoords =
+    --           Right $
+    --             Coordinates
+    --               { lng = 285.64723120365153,
+    --                 lat = -8.664716530514133e-5,
+    --                 distance = 0.9833448914987339,
+    --                 lngSpeed = 1.0196505771457982,
+    --                 latSpeed = 1.4550248863443192e-5,
+    --                 distSpeed = 1.7364210462433863e-5
+    --               }
+    --     coords <- calculateCoordinates time Sun
+    --     debug $ "Getting coordinates for the sun: " ++ (show coords)
+    --     coords `compareCoords` expectedCoords
 
-      it "fails to calculate coordinates for Chiron if no ephemeris file is set" $ do
-        let time = julianDay 1989 1 6 0.0
-            expectedCoords = Left "SwissEph file 'seas_18.se1' not found in PATH '.:/users/ephe2/:/users/ephe/'"
-        coords <- calculateCoordinates time Chiron
-        debug $ "Getting chiron: " ++ (show coords)
-        coords `shouldBe` expectedCoords
+    --   it "fails to calculate coordinates for Chiron if no ephemeris file is set" $ do
+    --     let time = julianDay 1989 1 6 0.0
+    --         expectedCoords = Left "SwissEph file 'seas_18.se1' not found in PATH '.:/users/ephe2/:/users/ephe/'"
+    --     coords <- calculateCoordinates time Chiron
+    --     debug $ "Getting chiron: " ++ (show coords)
+    --     coords `shouldBe` expectedCoords
 
     describe "calculateCuspsStrict" $ do
       it "calculates cusps and angles for a given place and time, keeping the same house system (not near the poles)" $ do
@@ -124,18 +124,18 @@ spec = do
           debug $ "prop testing cusps (non-polar): " ++ (show calcs)
           assert $ (systemUsed calcs) == houseSystem
 
-  around_ ( withEphemerides ephePath ) $ do
-    describe "calculateCoordinates with bundled ephemeris" $ do
-      prop "calculates coordinates for any of the planets in a wide range of time." $
-        forAll genCoordinatesQuery $ \(time, planet) -> monadicIO $ do
-          coords <- run $ calculateCoordinates time planet
-          debug $ "prop testing good coords: " ++ (show coords)
-          assert $ isRight coords
-      prop "is unable to calculate coordinates for times before or after the bundled ephemerides" $ 
-        forAll genBadCoordinatesQuery $ \(time, planet) -> monadicIO $ do
-          coords <- run $ calculateCoordinates time planet
-          debug $ "prop testing bad coords: " ++ (show coords)
-          assert $ isLeft coords
+  -- around_ ( withEphemerides ephePath ) $ do
+  --   describe "calculateCoordinates with bundled ephemeris" $ do
+  --     prop "calculates coordinates for any of the planets in a wide range of time." $
+  --       forAll genCoordinatesQuery $ \(time, planet) -> monadicIO $ do
+  --         coords <- run $ calculateCoordinates time planet
+  --         debug $ "prop testing good coords: " ++ (show coords)
+  --         assert $ isRight coords
+  --     prop "is unable to calculate coordinates for times before or after the bundled ephemerides" $ 
+  --       forAll genBadCoordinatesQuery $ \(time, planet) -> monadicIO $ do
+  --         coords <- run $ calculateCoordinates time planet
+  --         debug $ "prop testing bad coords: " ++ (show coords)
+  --         assert $ isLeft coords
 
 {- For reference, here's an official test output from swetest.c as retrieved from the swetest page:
 https://www.astro.com/cgi/swetest.cgi?b=6.1.1989&n=1&s=1&p=p&e=-eswe&f=PlbRS&arg=

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -4,8 +4,6 @@ module SwissEphemerisSpec (spec) where
 
 import SwissEphemeris
 import Test.Hspec
-import System.Directory (makeAbsolute)
-import System.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck
 import Test.QuickCheck.Monadic
 import Data.Either (isLeft, isRight)
@@ -18,8 +16,7 @@ import Test.Hspec.QuickCheck (prop)
 -- note the `PlbRS` format, which outputs latitude and longitude as decimals, not degrees
 -- for easier comparison.
 ephePath :: FilePath
-ephePath = unsafePerformIO $ makeAbsolute  "./swedist/sweph_18"
-{-# NOINLINE ephePath #-}
+ephePath = "./swedist/sweph_18"
 
 spec :: Spec
 spec = do

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -8,7 +8,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Monadic
 import Data.Either (isLeft, isRight)
 import Test.Hspec.QuickCheck (prop)
-import Debug.Trace (trace)
+import Debug.Trace (trace, traceM)
 
 -- to verify that we're calling things correctly, refer to the swiss ephemeris test page:
 -- https://www.astro.com/swisseph/swetest.htm
@@ -35,13 +35,15 @@ spec = do
                     latSpeed = 1.4550248863443192e-5,
                     distSpeed = 1.7364210462433863e-5
                   }
-        coords <- trace "Getting coordinates for the sun" $ calculateCoordinates time Sun
+        coords <- calculateCoordinates time Sun
+        traceM $ "Getting coordinates for the sun" ++ (show coords)
         coords `compareCoords` expectedCoords
 
       it "fails to calculate coordinates for Chiron if no ephemeris file is set" $ do
         let time = julianDay 1989 1 6 0.0
             expectedCoords = Left "SwissEph file 'seas_18.se1' not found in PATH '.:/users/ephe2/:/users/ephe/'"
-        coords <- trace "Getting chiron" $ calculateCoordinates time Chiron
+        coords <- calculateCoordinates time Chiron
+        traceM $ "Getting chiron" ++ (show coords)
         coords `shouldBe` expectedCoords
 
     describe "calculateCuspsStrict" $ do
@@ -76,14 +78,16 @@ spec = do
                   }
                 Placidus
 
-        calcs <- trace "strict cusps succeeds" $ calculateCuspsStrict time place Placidus
+        calcs <- calculateCuspsStrict time place Placidus
+        traceM $ "strict cusps succeeds" ++ (show calcs)
         calcs `compareCalculations` (Right expectedCalculations) 
 
       it "fails when using a house system that is unable to calculate cusps near the poles" $ do
         let time = julianDay 1989 1 6 0.0
             -- Longyearbyen:
             place = defaultCoordinates {lat = 78.2232, lng = 15.6267}
-        calcs <- trace "strict cusps fails" $ calculateCuspsStrict time place Placidus
+        calcs <- calculateCuspsStrict time place Placidus
+        traceM $ "strict cusps fails" ++ (show calcs)
         calcs `shouldSatisfy` isLeft
 
     describe "calculateCuspsLenient" $ do
@@ -92,7 +96,8 @@ spec = do
             -- Longyearbyen:
             place = defaultCoordinates {lat = 78.2232, lng = 15.6267}
             expected = CuspsCalculation {houseCusps = HouseCusps {i = 190.88156009524067, ii = 226.9336677703179, iii = 262.9857754453951, iv = 299.0378831204723, v = 322.9857754453951, vi = 346.9336677703179, vii = 10.881560095240673, viii = 46.933667770317925, ix = 82.98577544539512, x = 119.03788312047234, xi = 142.98577544539512, xii = 166.9336677703179}, angles = Angles {ascendant = 190.88156009524067, mc = 119.03788312047234, armc = 121.17906552074543, vertex = 36.408617337292114, equatorialAscendant = 213.4074315205484, coAscendantKoch = 335.2547300150891, coAscendantMunkasey = 210.81731854391526, polarAscendant = 155.2547300150891}, systemUsed = Porphyrius} 
-        calcs <- trace "lenient cusps succeeds" $ calculateCuspsLenient time place Placidus
+        calcs <- calculateCuspsLenient time place Placidus
+        traceM $ "lenient cusps succeeds" ++ show calcs
         (systemUsed calcs) `shouldBe` Porphyrius
         (Right calcs) `compareCalculations` (Right expected)
 
@@ -104,18 +109,21 @@ spec = do
         -- > In addition, Sunshine houses may fail, e.g. when required for a date which is outside the time range of our solar ephemeris. Here, also, Porphyry houses will be provided.
         -- from: https://www.astro.com/swisseph/swephprg.htm
         forAll genCuspsQuery $ \((la, lo), time, houseSystem) -> monadicIO $ do
-          calcs <- trace "prop testing cusps" $ run $ calculateCusps time (defaultCoordinates{lat = la, lng = lo}) houseSystem
+          calcs <- run $ calculateCusps time (defaultCoordinates{lat = la, lng = lo}) houseSystem
+          traceM $ "prop testing cusps" ++ (show calcs)
           assert $ (systemUsed calcs) `elem` [houseSystem, Porphyrius]
 
   around_ ( withEphemerides ephePath ) $ do
     describe "calculateCoordinates with bundled ephemeris" $ do
       prop "calculates coordinates for any of the planets in a wide range of time." $
         forAll genCoordinatesQuery $ \(time, planet) -> monadicIO $ do
-          coords <- trace "prop testing good coords" $ run $ calculateCoordinates time planet
+          coords <- run $ calculateCoordinates time planet
+          traceM $ "prop testing good coords" ++ (show coords)
           assert $ isRight coords
       prop "is unable to calculate coordinates for times before or after the bundled ephemerides" $ 
         forAll genBadCoordinatesQuery $ \(time, planet) -> monadicIO $ do
-          coords <- trace "prop testing bad coords" $ run $ calculateCoordinates time planet
+          coords <- run $ calculateCoordinates time planet
+          traceM $ "prop testing bad coords" ++ (show coords)
           assert $ isLeft coords
 
 {- For reference, here's an official test output from swetest.c as retrieved from the swetest page:

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -41,14 +41,14 @@ spec = do
                     distSpeed = 1.7364210462433863e-5
                   }
         coords <- calculateCoordinates time Sun
-        debug $ "Getting coordinates for the sun" ++ (show coords)
+        debug $ "Getting coordinates for the sun: " ++ (show coords)
         coords `compareCoords` expectedCoords
 
       it "fails to calculate coordinates for Chiron if no ephemeris file is set" $ do
         let time = julianDay 1989 1 6 0.0
             expectedCoords = Left "SwissEph file 'seas_18.se1' not found in PATH '.:/users/ephe2/:/users/ephe/'"
         coords <- calculateCoordinates time Chiron
-        debug $ "Getting chiron" ++ (show coords)
+        debug $ "Getting chiron: " ++ (show coords)
         coords `shouldBe` expectedCoords
 
     describe "calculateCuspsStrict" $ do
@@ -84,7 +84,7 @@ spec = do
                 Placidus
 
         calcs <- calculateCuspsStrict time place Placidus
-        debug $ "strict cusps succeeds" ++ (show calcs)
+        debug $ "strict cusps succeeds: " ++ (show calcs)
         calcs `compareCalculations` (Right expectedCalculations) 
 
       it "fails when using a house system that is unable to calculate cusps near the poles" $ do
@@ -92,7 +92,7 @@ spec = do
             -- Longyearbyen:
             place = defaultCoordinates {lat = 78.2232, lng = 15.6267}
         calcs <- calculateCuspsStrict time place Placidus
-        debug $ "strict cusps fails" ++ (show calcs)
+        debug $ "strict cusps fails: " ++ (show calcs)
         calcs `shouldSatisfy` isLeft
 
     describe "calculateCuspsLenient" $ do
@@ -102,7 +102,7 @@ spec = do
             place = defaultCoordinates {lat = 78.2232, lng = 15.6267}
             expected = CuspsCalculation {houseCusps = HouseCusps {i = 190.88156009524067, ii = 226.9336677703179, iii = 262.9857754453951, iv = 299.0378831204723, v = 322.9857754453951, vi = 346.9336677703179, vii = 10.881560095240673, viii = 46.933667770317925, ix = 82.98577544539512, x = 119.03788312047234, xi = 142.98577544539512, xii = 166.9336677703179}, angles = Angles {ascendant = 190.88156009524067, mc = 119.03788312047234, armc = 121.17906552074543, vertex = 36.408617337292114, equatorialAscendant = 213.4074315205484, coAscendantKoch = 335.2547300150891, coAscendantMunkasey = 210.81731854391526, polarAscendant = 155.2547300150891}, systemUsed = Porphyrius} 
         calcs <- calculateCuspsLenient time place Placidus
-        debug $ "lenient cusps succeeds" ++ show calcs
+        debug $ "lenient cusps succeeds: " ++ show calcs
         (systemUsed calcs) `shouldBe` Porphyrius
         (Right calcs) `compareCalculations` (Right expected)
 
@@ -115,13 +115,13 @@ spec = do
         -- from: https://www.astro.com/swisseph/swephprg.htm
         forAll genCuspsQuery $ \((la, lo), time, houseSystem) -> monadicIO $ do
           calcs <- run $ calculateCusps time (defaultCoordinates{lat = la, lng = lo}) houseSystem
-          debug $ "prop testing cusps" ++ (show calcs)
+          debug $ "prop testing cusps: " ++ (show calcs)
           assert $ (systemUsed calcs) `elem` [houseSystem, Porphyrius]
 
       prop "calculates cusps and angles for points outside of the polar circles in the requested house system, no fallback." $
         forAll genCuspsNonPolarQuery $ \((la, lo), time, houseSystem) -> monadicIO $ do
           calcs <- run $ calculateCusps time (defaultCoordinates{lat = la, lng = lo}) houseSystem
-          debug $ "prop testing cusps (non-polar)" ++ (show calcs)
+          debug $ "prop testing cusps (non-polar): " ++ (show calcs)
           assert $ (systemUsed calcs) == houseSystem
 
   around_ ( withEphemerides ephePath ) $ do
@@ -129,12 +129,12 @@ spec = do
       prop "calculates coordinates for any of the planets in a wide range of time." $
         forAll genCoordinatesQuery $ \(time, planet) -> monadicIO $ do
           coords <- run $ calculateCoordinates time planet
-          debug $ "prop testing good coords" ++ (show coords)
+          debug $ "prop testing good coords: " ++ (show coords)
           assert $ isRight coords
       prop "is unable to calculate coordinates for times before or after the bundled ephemerides" $ 
         forAll genBadCoordinatesQuery $ \(time, planet) -> monadicIO $ do
           coords <- run $ calculateCoordinates time planet
-          debug $ "prop testing bad coords" ++ (show coords)
+          debug $ "prop testing bad coords: " ++ (show coords)
           assert $ isLeft coords
 
 {- For reference, here's an official test output from swetest.c as retrieved from the swetest page:

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -8,7 +8,6 @@ import Test.QuickCheck
 import Test.QuickCheck.Monadic
 import Data.Either (isLeft, isRight)
 import Test.Hspec.QuickCheck (prop)
-import Debug.Trace (trace, traceM)
 
 -- to verify that we're calling things correctly, refer to the swiss ephemeris test page:
 -- https://www.astro.com/swisseph/swetest.htm
@@ -18,11 +17,6 @@ import Debug.Trace (trace, traceM)
 -- for easier comparison.
 ephePath :: FilePath
 ephePath = "./swedist/sweph_18"
-
-debug :: Applicative f => String -> f ()
---debug = traceM
-debug _ = pure ()
---debug _ = traceM "Exercising stdout"
 
 spec :: Spec
 spec = do
@@ -41,14 +35,12 @@ spec = do
                     distSpeed = 1.7364210462433863e-5
                   }
         coords <- calculateCoordinates time Sun
-        debug $ "Getting coordinates for the sun: " ++ (show coords)
         coords `compareCoords` expectedCoords
 
       it "fails to calculate coordinates for Chiron if no ephemeris file is set" $ do
         let time = julianDay 1989 1 6 0.0
             expectedCoords = Left "SwissEph file 'seas_18.se1' not found in PATH '.:/users/ephe2/:/users/ephe/'"
         coords <- calculateCoordinates time Chiron
-        debug $ "Getting chiron: " ++ (show coords)
         coords `shouldBe` expectedCoords
 
     describe "calculateCuspsStrict" $ do
@@ -84,7 +76,6 @@ spec = do
                 Placidus
 
         calcs <- calculateCuspsStrict time place Placidus
-        debug $ "strict cusps succeeds: " ++ (show calcs)
         calcs `compareCalculations` (Right expectedCalculations) 
 
       it "fails when using a house system that is unable to calculate cusps near the poles" $ do
@@ -92,7 +83,6 @@ spec = do
             -- Longyearbyen:
             place = defaultCoordinates {lat = 78.2232, lng = 15.6267}
         calcs <- calculateCuspsStrict time place Placidus
-        debug $ "strict cusps fails: " ++ (show calcs)
         calcs `shouldSatisfy` isLeft
 
     describe "calculateCuspsLenient" $ do
@@ -102,7 +92,6 @@ spec = do
             place = defaultCoordinates {lat = 78.2232, lng = 15.6267}
             expected = CuspsCalculation {houseCusps = HouseCusps {i = 190.88156009524067, ii = 226.9336677703179, iii = 262.9857754453951, iv = 299.0378831204723, v = 322.9857754453951, vi = 346.9336677703179, vii = 10.881560095240673, viii = 46.933667770317925, ix = 82.98577544539512, x = 119.03788312047234, xi = 142.98577544539512, xii = 166.9336677703179}, angles = Angles {ascendant = 190.88156009524067, mc = 119.03788312047234, armc = 121.17906552074543, vertex = 36.408617337292114, equatorialAscendant = 213.4074315205484, coAscendantKoch = 335.2547300150891, coAscendantMunkasey = 210.81731854391526, polarAscendant = 155.2547300150891}, systemUsed = Porphyrius} 
         calcs <- calculateCuspsLenient time place Placidus
-        debug $ "lenient cusps succeeds: " ++ show calcs
         (systemUsed calcs) `shouldBe` Porphyrius
         (Right calcs) `compareCalculations` (Right expected)
 
@@ -115,13 +104,11 @@ spec = do
         -- from: https://www.astro.com/swisseph/swephprg.htm
         forAll genCuspsQuery $ \((la, lo), time, houseSystem) -> monadicIO $ do
           calcs <- run $ calculateCusps time (defaultCoordinates{lat = la, lng = lo}) houseSystem
-          debug $ "prop testing cusps: " ++ (show calcs)
           assert $ (systemUsed calcs) `elem` [houseSystem, Porphyrius]
 
       prop "calculates cusps and angles for points outside of the polar circles in the requested house system, no fallback." $
         forAll genCuspsNonPolarQuery $ \((la, lo), time, houseSystem) -> monadicIO $ do
           calcs <- run $ calculateCusps time (defaultCoordinates{lat = la, lng = lo}) houseSystem
-          debug $ "prop testing cusps (non-polar): " ++ (show calcs)
           assert $ (systemUsed calcs) == houseSystem
 
   around_ ( withEphemerides ephePath ) $ do
@@ -129,12 +116,10 @@ spec = do
       prop "calculates coordinates for any of the planets in a wide range of time." $
         forAll genCoordinatesQuery $ \(time, planet) -> monadicIO $ do
           coords <- run $ calculateCoordinates time planet
-          debug $ "prop testing good coords: " ++ (show coords)
           assert $ isRight coords
       prop "is unable to calculate coordinates for times before or after the bundled ephemerides" $ 
         forAll genBadCoordinatesQuery $ \(time, planet) -> monadicIO $ do
           coords <- run $ calculateCoordinates time planet
-          debug $ "prop testing bad coords: " ++ (show coords)
           assert $ isLeft coords
 
 {- For reference, here's an official test output from swetest.c as retrieved from the swetest page:

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -27,29 +27,29 @@ debug _ = pure ()
 spec :: Spec
 spec = do
   around_ ( withoutEphemerides ) $ do
-    -- describe "calculateCoordinates" $ do
-    --   it "calculates coordinates for the Sun for a specific day" $ do
-    --     let time = julianDay 1989 1 6 0.0
-    --         expectedCoords =
-    --           Right $
-    --             Coordinates
-    --               { lng = 285.64723120365153,
-    --                 lat = -8.664716530514133e-5,
-    --                 distance = 0.9833448914987339,
-    --                 lngSpeed = 1.0196505771457982,
-    --                 latSpeed = 1.4550248863443192e-5,
-    --                 distSpeed = 1.7364210462433863e-5
-    --               }
-    --     coords <- calculateCoordinates time Sun
-    --     debug $ "Getting coordinates for the sun: " ++ (show coords)
-    --     coords `compareCoords` expectedCoords
+    describe "calculateCoordinates" $ do
+      it "calculates coordinates for the Sun for a specific day" $ do
+        let time = julianDay 1989 1 6 0.0
+            expectedCoords =
+              Right $
+                Coordinates
+                  { lng = 285.64723120365153,
+                    lat = -8.664716530514133e-5,
+                    distance = 0.9833448914987339,
+                    lngSpeed = 1.0196505771457982,
+                    latSpeed = 1.4550248863443192e-5,
+                    distSpeed = 1.7364210462433863e-5
+                  }
+        coords <- calculateCoordinates time Sun
+        debug $ "Getting coordinates for the sun: " ++ (show coords)
+        coords `compareCoords` expectedCoords
 
-    --   it "fails to calculate coordinates for Chiron if no ephemeris file is set" $ do
-    --     let time = julianDay 1989 1 6 0.0
-    --         expectedCoords = Left "SwissEph file 'seas_18.se1' not found in PATH '.:/users/ephe2/:/users/ephe/'"
-    --     coords <- calculateCoordinates time Chiron
-    --     debug $ "Getting chiron: " ++ (show coords)
-    --     coords `shouldBe` expectedCoords
+      it "fails to calculate coordinates for Chiron if no ephemeris file is set" $ do
+        let time = julianDay 1989 1 6 0.0
+            expectedCoords = Left "SwissEph file 'seas_18.se1' not found in PATH '.:/users/ephe2/:/users/ephe/'"
+        coords <- calculateCoordinates time Chiron
+        debug $ "Getting chiron: " ++ (show coords)
+        coords `shouldBe` expectedCoords
 
     describe "calculateCuspsStrict" $ do
       it "calculates cusps and angles for a given place and time, keeping the same house system (not near the poles)" $ do
@@ -124,18 +124,18 @@ spec = do
           debug $ "prop testing cusps (non-polar): " ++ (show calcs)
           assert $ (systemUsed calcs) == houseSystem
 
-  -- around_ ( withEphemerides ephePath ) $ do
-  --   describe "calculateCoordinates with bundled ephemeris" $ do
-  --     prop "calculates coordinates for any of the planets in a wide range of time." $
-  --       forAll genCoordinatesQuery $ \(time, planet) -> monadicIO $ do
-  --         coords <- run $ calculateCoordinates time planet
-  --         debug $ "prop testing good coords: " ++ (show coords)
-  --         assert $ isRight coords
-  --     prop "is unable to calculate coordinates for times before or after the bundled ephemerides" $ 
-  --       forAll genBadCoordinatesQuery $ \(time, planet) -> monadicIO $ do
-  --         coords <- run $ calculateCoordinates time planet
-  --         debug $ "prop testing bad coords: " ++ (show coords)
-  --         assert $ isLeft coords
+  around_ ( withEphemerides ephePath ) $ do
+    describe "calculateCoordinates with bundled ephemeris" $ do
+      prop "calculates coordinates for any of the planets in a wide range of time." $
+        forAll genCoordinatesQuery $ \(time, planet) -> monadicIO $ do
+          coords <- run $ calculateCoordinates time planet
+          debug $ "prop testing good coords: " ++ (show coords)
+          assert $ isRight coords
+      prop "is unable to calculate coordinates for times before or after the bundled ephemerides" $ 
+        forAll genBadCoordinatesQuery $ \(time, planet) -> monadicIO $ do
+          coords <- run $ calculateCoordinates time planet
+          debug $ "prop testing bad coords: " ++ (show coords)
+          assert $ isLeft coords
 
 {- For reference, here's an official test output from swetest.c as retrieved from the swetest page:
 https://www.astro.com/cgi/swetest.cgi?b=6.1.1989&n=1&s=1&p=p&e=-eswe&f=PlbRS&arg=

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -8,6 +8,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Monadic
 import Data.Either (isLeft, isRight)
 import Test.Hspec.QuickCheck (prop)
+import Debug.Trace (trace)
 
 -- to verify that we're calling things correctly, refer to the swiss ephemeris test page:
 -- https://www.astro.com/swisseph/swetest.htm
@@ -34,13 +35,13 @@ spec = do
                     latSpeed = 1.4550248863443192e-5,
                     distSpeed = 1.7364210462433863e-5
                   }
-        coords <- calculateCoordinates time Sun
+        coords <- trace "Getting coordinates for the sun" $ calculateCoordinates time Sun
         coords `compareCoords` expectedCoords
 
       it "fails to calculate coordinates for Chiron if no ephemeris file is set" $ do
         let time = julianDay 1989 1 6 0.0
             expectedCoords = Left "SwissEph file 'seas_18.se1' not found in PATH '.:/users/ephe2/:/users/ephe/'"
-        coords <- calculateCoordinates time Chiron
+        coords <- trace "Getting chiron" $ calculateCoordinates time Chiron
         coords `shouldBe` expectedCoords
 
     describe "calculateCuspsStrict" $ do
@@ -75,14 +76,14 @@ spec = do
                   }
                 Placidus
 
-        calcs <- calculateCuspsStrict time place Placidus
+        calcs <- trace "strict cusps succeeds" $ calculateCuspsStrict time place Placidus
         calcs `compareCalculations` (Right expectedCalculations) 
 
       it "fails when using a house system that is unable to calculate cusps near the poles" $ do
         let time = julianDay 1989 1 6 0.0
             -- Longyearbyen:
             place = defaultCoordinates {lat = 78.2232, lng = 15.6267}
-        calcs <- calculateCuspsStrict time place Placidus
+        calcs <- trace "strict cusps fails" $ calculateCuspsStrict time place Placidus
         calcs `shouldSatisfy` isLeft
 
     describe "calculateCuspsLenient" $ do
@@ -91,7 +92,7 @@ spec = do
             -- Longyearbyen:
             place = defaultCoordinates {lat = 78.2232, lng = 15.6267}
             expected = CuspsCalculation {houseCusps = HouseCusps {i = 190.88156009524067, ii = 226.9336677703179, iii = 262.9857754453951, iv = 299.0378831204723, v = 322.9857754453951, vi = 346.9336677703179, vii = 10.881560095240673, viii = 46.933667770317925, ix = 82.98577544539512, x = 119.03788312047234, xi = 142.98577544539512, xii = 166.9336677703179}, angles = Angles {ascendant = 190.88156009524067, mc = 119.03788312047234, armc = 121.17906552074543, vertex = 36.408617337292114, equatorialAscendant = 213.4074315205484, coAscendantKoch = 335.2547300150891, coAscendantMunkasey = 210.81731854391526, polarAscendant = 155.2547300150891}, systemUsed = Porphyrius} 
-        calcs <- calculateCuspsLenient time place Placidus
+        calcs <- trace "lenient cusps succeeds" $ calculateCuspsLenient time place Placidus
         (systemUsed calcs) `shouldBe` Porphyrius
         (Right calcs) `compareCalculations` (Right expected)
 
@@ -103,18 +104,18 @@ spec = do
         -- > In addition, Sunshine houses may fail, e.g. when required for a date which is outside the time range of our solar ephemeris. Here, also, Porphyry houses will be provided.
         -- from: https://www.astro.com/swisseph/swephprg.htm
         forAll genCuspsQuery $ \((la, lo), time, houseSystem) -> monadicIO $ do
-          calcs <- run $ calculateCusps time (defaultCoordinates{lat = la, lng = lo}) houseSystem
+          calcs <- trace "prop testing cusps" $ run $ calculateCusps time (defaultCoordinates{lat = la, lng = lo}) houseSystem
           assert $ (systemUsed calcs) `elem` [houseSystem, Porphyrius]
 
   around_ ( withEphemerides ephePath ) $ do
     describe "calculateCoordinates with bundled ephemeris" $ do
       prop "calculates coordinates for any of the planets in a wide range of time." $
         forAll genCoordinatesQuery $ \(time, planet) -> monadicIO $ do
-          coords <- run $ calculateCoordinates time planet
+          coords <- trace "prop testing good coords" $ run $ calculateCoordinates time planet
           assert $ isRight coords
       prop "is unable to calculate coordinates for times before or after the bundled ephemerides" $ 
         forAll genBadCoordinatesQuery $ \(time, planet) -> monadicIO $ do
-          coords <- run $ calculateCoordinates time planet
+          coords <- trace "prop testing bad coords" $ run $ calculateCoordinates time planet
           assert $ isLeft coords
 
 {- For reference, here's an official test output from swetest.c as retrieved from the swetest page:


### PR DESCRIPTION
Closes #8 

Turns out allocating a pointer for the error string, vs. the `char [256]` that the [swiss ephemeris documentation](https://www.astro.com/swisseph/swephprg.htm#_Toc49847825) mentions repeatedly was causing a memory leak. We now allocate space for only 256 characters -- no more segfaults!

Also, some "undefined behavior" is also warned against in the documentation for [`Foreign.Marshal.Alloc`](https://hackage.haskell.org/package/base-4.14.0.0/docs/Foreign-Marshal-Alloc.html#g:2). After reading more, I guess I _could_ use [`allocaBytes`](https://hackage.haskell.org/package/base-4.14.0.0/docs/Foreign-Marshal-Alloc.html#v:allocaBytes) but I'm not 100% confident that a `char` is 1 byte in all platforms? I'd rather have Haskell know that it must allocate an array large enough for 256 [`CChars`](https://hackage.haskell.org/package/base-4.14.0.0/docs/Foreign-C-Types.html#t:CChar). Another option is the more explicit [`CStringLen`](https://hackage.haskell.org/package/base-4.14.0.0/docs/Foreign-C-String.html#t:CStringLen) type, though I'm not sure how much clearer that would be than hewing close to the original library and going with an array of 256 chars explicitly?

You can see in the code itself that `serr` is usually defined as a char array of size `AS_MAXCH` which is defined in:

https://github.com/lfborjas/swiss-ephemeris/blob/c31d31286e708537e89b857dc7f607ea8eb3b48d/csrc/sweodef.h#L266

Most conspicuously, in `swe_calc`, which is called by `swe_calc_ut`:

https://github.com/lfborjas/swiss-ephemeris/blob/c31d31286e708537e89b857dc7f607ea8eb3b48d/csrc/sweph.c#L581

tl;dr: RTFM, the signature was there all along:

```
long swe_calc_ut(

double tjd_ut,       /* Julian day number, Universal Time */

int ipl,                  /* planet number */

long iflag,          /* flag bits */

double *xx,          /* target address for 6 position values: longitude, latitude, distance, long. speed, lat. speed, dist. speed */

char *serr);         /* 256 bytes for error string */
```

## Notes

Some good references for tooling:

* https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
* https://markkarpov.com/post/github-actions-for-haskell-ci.html

And for actual troubleshooting the potential segfault:

https://github.com/ndmitchell/spaceleak

In the end, I was able to reproduce the issue more reliably in my mac mini by building the tests with 

    stack --profile test

And running them with the `+RTS -K1K -s` options as per the above link -- one should be able to send these to `stack --profile test`, but I wasn't able to figure it out, this proved to be reliable however:

    .stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/swiss-ephemeris-test/swiss-ephemeris-test +RTS -K1K -s

Which also prints some interesting memory usage information:

```
      19,366,312 bytes allocated in the heap
         492,760 bytes copied during GC
         260,944 bytes maximum residency (2 sample(s))
          76,720 bytes maximum slop
               0 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0        15 colls,    15 par    0.006s   0.002s     0.0001s    0.0006s
  Gen  1         2 colls,     1 par    0.001s   0.001s     0.0003s    0.0004s

  Parallel GC work balance: 49.74% (serial 0%, perfect 100%)

  TASKS: 20 (1 bound, 19 peak workers (19 total), using -N6)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.009s elapsed)
  MUT     time    0.068s  (  0.080s elapsed)
  GC      time    0.007s  (  0.002s elapsed)
  RP      time    0.000s  (  0.000s elapsed)
  PROF    time    0.000s  (  0.000s elapsed)
  EXIT    time    0.000s  (  0.001s elapsed)
  Total   time    0.076s  (  0.092s elapsed)

  Alloc rate    283,718,073 bytes per MUT second

  Productivity  89.3% of total user, 87.4% of total elapsed
```

When the memory leak was still present, I managed to get it from the above command, and also from some `gdb` sessions:

```
luis@mac-mini ~/c/l/swiss-ephemeris (late-night-ci-poking)> gdb --args .stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/swiss-ephemeris-test/swiss-ephemeris-test +RTS -K1K -V0
GNU gdb (GDB) 9.2
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-apple-darwin19.5.0".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from .stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/swiss-ephemeris-test/swiss-ephemeris-test...
Reading symbols from /Users/luis/code/lfborjas/swiss-ephemeris/.stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/swiss-ephemeris-test/swiss-ephemeris-test.dSYM/Contents/Resources/DWARF/swiss-ephemeris-test...
(gdb) run
Starting program: /Users/luis/code/lfborjas/swiss-ephemeris/.stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/swiss-ephemeris-test/swiss-ephemeris-test +RTS -K1K -V0
[New Thread 0x2803 of process 84588]
[New Thread 0x1b03 of process 84588]
[New Thread 0x2603 of process 84588]
warning: unhandled dyld version (16)

SwissEphemeris
  calculateCoordinates
    calculates coordinates for the Sun for a specific day
    fails to calculate coordinates for Chiron if no ephemeris file is set
  calculateCuspsStrict
    calculates cusps and angles for a given place and time, keeping the same house system (not near the poles)
    fails when using a house system that is unable to calculate cusps near the poles
  calculateCuspsLenient
    falls back to Porphyry when calculating cusps for a place near the poles
[New Thread 0x1a0f of process 84588]
[New Thread 0x1c03 of process 84588]
[New Thread 0x1d03 of process 84588]
[New Thread 0x1e03 of process 84588]
[New Thread 0x1f03 of process 84588]
[New Thread 0x2003 of process 84588]
[New Thread 0x2103 of process 84588]
[New Thread 0x2203 of process 84588]
[New Thread 0x2303 of process 84588]
[New Thread 0x2403 of process 84588]
[New Thread 0x2503 of process 84588]
[New Thread 0x2a03 of process 84588]
[New Thread 0x2b03 of process 84588]
[New Thread 0x2c03 of process 84588]
[New Thread 0x2d03 of process 84588]
[New Thread 0x2e03 of process 84588]
[New Thread 0x5203 of process 84588]
[New Thread 0x5303 of process 84588]
[New Thread 0x5403 of process 84588]

Thread 4 received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x1a0f of process 84588]
evacuate (p=<optimized out>) at /Users/builder/Desktop/builds/V164sjj5/0/ghc/ghc/rts/sm/Evac.c:521
521	/Users/builder/Desktop/builds/V164sjj5/0/ghc/ghc/rts/sm/Evac.c: No such file or directory.
(gdb) bt
#0  evacuate (p=<optimized out>) at /Users/builder/Desktop/builds/V164sjj5/0/ghc/ghc/rts/sm/Evac.c:521
#1  0x0000004200626628 in ?? ()
#2  0x0000004200626628 in ?? ()
#3  0x0000000000000000 in ?? ()
(gdb) 
```

... which shows that things went very wrong very early on. Also that apparently `hspec` runs threaded?