### PR TITLE
Refactoring of cusps: they're now a list, house system comes first

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,15 @@
 # Changelog for swiss-ephemeris
 
+## v1.0.0.0 (2020-09-07)
+
+* Refactor the `calculateCusps` function:
+  - Return a simple list of cusps. This allows for future implementations of exotic systems
+    that have more (or fewer?) cusps, and hews closer to regular usage (which iterates over the cusps.)
+  - The house system comes first, to allow for more ergonomic partial application for uses where one system is
+    the "default" (e.g. `traditionalCusps = calculateCusps Placidus`.)
+* Cleans up haddocks, adds many links to the original docs (and notes the headings, since updates to those
+  seem to break hyperlinking?)
+
 ## v0.3.1.0
 
 * Fixes occasional segmentation fault (caught most often in the more memory-strapped CI server than in my computer,)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ main = do
 
   -- locate all bodies between the Sun and Chiron (further asteroids currently not supported, but they're an enum entry away)
   -- use the Placidus house system, which is the most traditional.
-  forM_ [Sun .. Chiron] $ \planet -> do
+  forM_ [Sun .. Chiron] $ \planet ->
     -- if no ephemerides data is available for the given planetary body, a `Left` value
     -- will be returned.
     coord <- calculateCoordinates time planet
@@ -28,12 +28,13 @@ main = do
   -- Calculate cusps for the given time and place, preferring the `Placidus` system.
   -- note that the underlying library may decide to use a different system if it can't
   -- calculate cusps (happens for the Placidus and Koch systems in locations near the poles.)
-  cusps <- calculateCusps time place Placidus
+  cusps <- calculateCusps Placidus time place
   putStrLn $ "Cusps: " <> show cusps
-  -- the underlying library, sadly, allocates some memory/file descriptors, you can free it with:
+
+  -- the underlying library, sadly, allocates some in-memory "cache" and file descriptors, you can free it with:
   closeEphemerides
 ```
-The above should print the latitude and longitude (plus some velocities) for all planets, and the cusps and other major angles.
+The above should print the latitude and longitude (plus some velocities) for all planets, and then the cusps and other major angles.
 
 There's also `withEphemerides` and `withoutEphemerides` bracket-style functions that take care of closing the files for you.
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                swiss-ephemeris
-version:             0.3.1.0
+version:             1.0.0.0
 github:              "lfborjas/swiss-ephemeris"
 license:             GPL-2
 author:              "Luis Borjas Reyes"

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -1,11 +1,27 @@
-{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveGeneric  #-}
+
+{-
+Module: SwissEphemeris
+Description: Bindings to the swisseph C library.
+License: GPL-2
+Maintainer: swiss-ephemeris@lfborjas.com
+Portability: POSIX
+
+Exposes types and functions that mirror the rich functionality of <https://www.astro.com/swisseph/swephinfo_e.htmSwiss Ephemeris>.
+Currently only certain bodies are exposed as data constructors, same for the major house systems. This is for the sake of simplicity
+only, if you need more, please refer to the bundled header files in @csrc@.
+
+You'll need to procure ephemeris files (see the official site, linked above) if you wish to obtain positions for planets outside of the main planetary
+bodies in the solar system, or before 3000 B.C or after 3000 A.D. For example, the test suite uses a small ephemeris
+that includes data for the asteroid Chiron, which is astrologically relevant in most modern practices.
+-}
 
 module SwissEphemeris (
     Planet(..)
 ,   HouseSystem(..)
 ,   JulianTime
+,   HouseCusp
 ,   Coordinates(..)
-,   HouseCusps(..)
 ,   Angles(..)
 ,   CuspsCalculation(..)
 -- constructors
@@ -23,7 +39,7 @@ module SwissEphemeris (
 ,   calculateCusps
 ,   calculateCuspsLenient
 ,   calculateCuspsStrict
-)where
+) where
 
 import           Foreign.SwissEphemeris
 
@@ -31,9 +47,15 @@ import           Foreign
 import           GHC.Generics
 import           Foreign.C.Types
 import           Foreign.C.String
-import           Data.Char                      ( ord )
+import           Data.Char (ord)
 import Control.Exception (bracket_)
 
+-- | All bodies for which a position can be calculated. Covers planets
+-- in the solar system, points between the Earth and the Moon, and
+-- astrologically significant asteroids (currently, only Chiron, but
+-- ephemerides data is available for others.)
+-- More at <https://www.astro.com/swisseph/swisseph.htm#_Toc46391648 2.1 Planetary and lunar ephemerides>
+-- and <https://www.astro.com/swisseph/swephprg.htm#_Toc49847827 3.2 bodies>
 data Planet = Sun
             | Moon
             | Mercury
@@ -52,6 +74,10 @@ data Planet = Sun
             | Chiron
             deriving (Show, Eq, Ord, Enum, Generic)
 
+-- | The major house systems. The underlying library supports many more, including the
+-- 36-cusp outlier Gauquelin.
+-- More info at <https://www.astro.com/swisseph/swisseph.htm#_Toc46391705 6.2 Astrological house systems>
+-- and <https://www.astro.com/swisseph/swephprg.htm#_Toc49847888 14. House cusp calculation>
 data HouseSystem = Placidus
                  | Koch
                  | Porphyrius
@@ -61,8 +87,21 @@ data HouseSystem = Placidus
                  | WholeSign
                  deriving (Show, Eq, Ord, Enum, Generic)
 
+-- | Represents an instant in Julian time.
+-- see:
+-- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847871 8. Date and time conversion functions>
+-- also cf. `julianDay`
 type JulianTime = Double
 
+-- | The cusp of a given "house" or "sector"
+-- see:
+-- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847888 14.1 House cusp calculation>
+-- and <https://www.astro.com/swisseph/swisseph.htm#_Toc46391705 6.2 Astrological house systems>
+type HouseCusp = Double
+
+-- | Position data for a celestial body, includes rotational speeds.
+-- see:
+-- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847837 3.4 Position and speed>
 data Coordinates = Coordinates
   {
     lng :: Double
@@ -71,11 +110,11 @@ data Coordinates = Coordinates
   , lngSpeed :: Double
   , latSpeed :: Double
   , distSpeed :: Double
-  } deriving (Show, Eq, Ord, Generic)
+  } deriving (Show, Eq, Generic)
 
 -- | Default coordinates with all zeros -- when you don't care about/know the velocities,
--- which would be the case for most inputs (though most outputs _will_ include them.)
--- Usually you'll set only lat and lng (e.g. `defaultCoordinates{lat = 1.4, lng = 4.1}`)
+-- which would be the case for most inputs (though most outputs /will/ include them.)
+-- Usually you'll set only lat and lng (e.g. @defaultCoordinates{lat = 1.4, lng = 4.1}@)
 -- when using it as an input for another function.
 defaultCoordinates :: Coordinates
 defaultCoordinates = Coordinates 0 0 0 0 0 0
@@ -84,22 +123,8 @@ defaultCoordinates = Coordinates 0 0 0 0 0 0
 mkCoordinates :: Coordinates
 mkCoordinates = defaultCoordinates
 
-data HouseCusps = HouseCusps
-  {
-      i :: Double
-    , ii :: Double
-    , iii :: Double
-    , iv :: Double
-    , v :: Double
-    , vi :: Double
-    , vii :: Double
-    , viii :: Double
-    , ix :: Double
-    , x :: Double
-    , xi :: Double
-    , xii :: Double
-  } deriving (Show, Eq, Generic)
-
+-- | Relevant angles: ascendant and MC, plus other "exotic" ones:
+-- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847890 14. House cusp calculation>
 data Angles = Angles
   {
     ascendant :: Double
@@ -112,14 +137,128 @@ data Angles = Angles
   , polarAscendant :: Double
   } deriving (Show, Eq, Generic)
 
+-- | Result of calculating the cusps for a given event; will include a list of
+-- cusps (most systems use 12 cusps, Gauquelin uses 36.)
 data CuspsCalculation = CuspsCalculation
   {
-    houseCusps :: HouseCusps
+    houseCusps :: [HouseCusp]
   , angles :: Angles
-  -- the underlying library may switch to Porphyrius
-  -- if it's unable to determine a cusp.
   , systemUsed :: HouseSystem
   } deriving (Show, Eq, Generic)
+
+-- | Given a path to a directory, point the underlying ephemerides library to it.
+-- You only need to call this function to provide an explicit ephemerides path,
+-- if the environment variable @SE_EPHE_PATH@ is set, it overrides this function.
+setEphemeridesPath :: FilePath -> IO ()
+setEphemeridesPath path =
+    withCString path $ \ephePath -> c_swe_set_ephe_path ephePath
+
+-- | Explicitly state that we don't want to set an ephemeris path,
+-- which will default to the built-in ephemeris, or use the directory
+-- in the @SE_EPHE_PATH@ environment variable, if set.
+setNoEphemeridesPath :: IO ()
+setNoEphemeridesPath = c_swe_set_ephe_path nullPtr
+
+-- | Explicitly release all "cache" pointers and open files obtained by the C
+-- library.
+closeEphemerides :: IO ()
+closeEphemerides = c_swe_close
+
+-- | Run a computation with a given ephemerides path open, and then close it. 
+-- Note that the computation does /not/ receive the ephemerides, 
+-- in keeping with the underlying library's side-effectful conventions.
+withEphemerides :: FilePath -> (IO a) -> IO a
+withEphemerides ephemeridesPath =
+  bracket_ (setEphemeridesPath ephemeridesPath)
+           (closeEphemerides)
+
+-- | Run a computation with no explicit ephemerides set, if the @SE_EPHE_PATH@
+-- environment variable is set, that will be used. If not, it'll fall back to
+-- in-memory data.
+withoutEphemerides :: (IO a) -> IO a
+withoutEphemerides =
+  bracket_ (setNoEphemeridesPath)
+           (closeEphemerides)
+
+-- | Given year, month and day as `Int` and a time as `Double`, return
+-- a single floating point number representing absolute `JulianTime`.
+-- The input date is assumed to be in Gregorian time.
+julianDay :: Int -> Int -> Int -> Double -> JulianTime
+julianDay year month day hour = realToFrac $ c_swe_julday y m d h gregorian
+  where
+    y = fromIntegral year
+    m = fromIntegral month
+    d = fromIntegral day
+    h = realToFrac hour
+
+-- | Given `JulianTime` (see `julianDay`),
+-- and a `Planet`, returns either the position of that planet at the given time,
+-- if available in the ephemeris, or an error. The underlying library may do IO
+-- when reading ephemerides data.
+calculateCoordinates :: JulianTime -> Planet -> IO (Either String Coordinates)
+calculateCoordinates time planet =
+    allocaArray 6 $ \coords -> allocaArray 256 $ \serr -> do
+        iflgret <- c_swe_calc (realToFrac time)
+                              (planetNumber planet)
+                              speed
+                              coords
+                              serr
+
+        if unCalcFlag iflgret < 0
+            then do
+                msg <- peekCAString serr
+                return $ Left msg
+            else do
+                result <- peekArray 6 coords
+                return $ Right $ coordinatesFromList $ map realToFrac result
+
+-- | Alias for `calculateCuspsLenient`
+calculateCusps :: JulianTime -> Coordinates -> HouseSystem -> IO CuspsCalculation
+calculateCusps = calculateCuspsLenient
+
+-- | Given a decimal representation of Julian Time (see `julianDay`),
+-- a set of `Coordinates` (see `mkCoordinates`,) and a `HouseSystem`
+-- (most applications use `Placidus`,) return a `CuspsCalculation` with all
+-- house cusps in that system, and other relevant `Angles`. 
+-- Notice that certain systems,
+-- like `Placidus` and `Koch`, are very likely to fail close to the polar circles; in this
+-- and other edge cases, the calculation returns cusps in the `Porphyrius` system.
+-- The underlying library may do IO when consulting ephemerides data.
+calculateCuspsLenient :: JulianTime -> Coordinates -> HouseSystem -> IO CuspsCalculation
+calculateCuspsLenient time loc sys = 
+    allocaArray 13 $ \cusps -> allocaArray 10 $ \ascmc -> do
+        rval <- c_swe_houses (realToFrac time)
+                             (realToFrac $ lat loc)
+                             (realToFrac $ lng loc)
+                             (fromIntegral $ toHouseSystemFlag sys)
+                             cusps
+                             ascmc
+        -- NOTE: the underlying library returns 13 cusps for most systems,
+        -- but the first element is always zero, to enable saying:
+        -- cusps[1] -> first house.
+        -- we treat it as a normal zero-indexed list.
+        -- TODO: the Gauquelin system may return 37 doubles,
+        -- we can try to support that, though do keep in mind that it may fall
+        -- back to porphyrius near the poles, which ony has 13 doubles returned.
+        (_:cuspsL)  <- peekArray 13 cusps
+        anglesL     <- peekArray 10 ascmc
+        return $ CuspsCalculation
+                  (map realToFrac $ cuspsL) 
+                  (anglesFromList $ map realToFrac $ anglesL)
+                  (if rval < 0 then Porphyrius else sys)
+
+-- | Unlike `calculateCuspsLenient`, return a `Left` value if the required house system
+-- couldn't be used to perform the calculations.
+calculateCuspsStrict :: JulianTime -> Coordinates -> HouseSystem -> IO (Either String CuspsCalculation)
+calculateCuspsStrict time loc sys = do
+  calcs@(CuspsCalculation _ _ sys') <- calculateCuspsLenient time loc sys
+  if sys' /= sys then
+    pure $ Left $ "Unable to calculate cusps in the requested house system (used " ++ (show sys') ++ " instead.)"
+  else
+    pure $ Right calcs
+
+
+-- Helpers
 
 -- in the C lib, house systems are expected as ASCII
 -- codes for specific characters (!)
@@ -133,133 +272,22 @@ toHouseSystemFlag Campanus      = ord 'C'
 toHouseSystemFlag Equal         = ord 'A'
 toHouseSystemFlag WholeSign     = ord 'W'
 
-
--- TODO: these fromList fns could be captured in a typeclass...
-fromList :: [Double] -> Coordinates
+coordinatesFromList :: [Double] -> Coordinates
 -- N.B. note that for some reason the SWE guys really like lng,lat coordinates
 -- though only for this one function: https://www.astro.com/swisseph/swephprg.htm#_Toc19111235
-fromList (sLng : sLat : c : d : e : f : _) = Coordinates sLng sLat c d e f
-fromList _                           = error "Invalid coordinate array"
+coordinatesFromList (sLng : sLat : c : d : e : f : _) = Coordinates sLng sLat c d e f
+-- the underlying library goes to great lengths to not return fewer than 6 data,
+-- it instead uses zeroes for unavailable entries.
+coordinatesFromList _                           = Coordinates 0 0 0 0 0 0
 
-fromCuspsList :: [Double] -> HouseCusps
-fromCuspsList (_ : _i : _ii : _iii : _iv : _v : _vi : _vii : _viii : _ix : _x : _xi : _xii : _)
-    = HouseCusps _i _ii _iii _iv _v _vi _vii _viii _ix _x _xi _xii
-fromCuspsList _ = error "Invalid cusps list"
-
-fromAnglesList :: [Double] -> Angles
-fromAnglesList (a : _mc : _armc : vtx : ea : cak : cam : pa : _ : _) =
+anglesFromList :: [Double] -> Angles
+anglesFromList (a : _mc : _armc : vtx : ea : cak : cam : pa : _ : _) =
     Angles a _mc _armc vtx ea cak cam pa
-fromAnglesList _ = error "Invalid angles list"
+-- the underlying library always returns _something_, defaulting to zero
+-- if the angle calculation doesn't apply.
+anglesFromList _ = Angles 0 0 0 0 0 0 0 0
 
 planetNumber :: Planet -> PlanetNumber
 planetNumber p = PlanetNumber $ CInt y
   where
     y = fromIntegral $ fromEnum p :: Int32
-
--- | Given a path to a directory, point the underlying ephemerides library to it.
--- You only need to call this function to provide an explicit ephemerides path,
--- if the environment variable SE_EPHE_PATH is set, it overrides this function.
-setEphemeridesPath :: FilePath -> IO ()
-setEphemeridesPath path =
-    withCString path $ \ephePath -> c_swe_set_ephe_path ephePath
-
--- | Explicitly state that we don't want to set an ephemeris path,
--- which will default to the built-in ephemeris, or use the directory
--- in the SE_EPHE_PATH environment variable, if set.
-setNoEphemeridesPath :: IO ()
-setNoEphemeridesPath = c_swe_set_ephe_path nullPtr
-
--- | Explicitly release all "cache" pointers and open files obtained by the C
--- library.
-closeEphemerides :: IO ()
-closeEphemerides = c_swe_close
-
--- | Run a computation with a given ephemerides path open, and then close it. 
--- Note that the computation does _not_ receive the ephemerides, 
--- in keeping with the underlying library's side-effectful conventions.
-withEphemerides :: FilePath -> (IO a) -> IO a
-withEphemerides ephemeridesPath =
-  bracket_ (setEphemeridesPath ephemeridesPath)
-           (closeEphemerides)
-
-
--- | Run a computation with no explicit ephemerides set, if the SE_EPHE_PATH
--- environment variable is set, that will be used. If not, it'll fall back to
--- in-memory data.
-withoutEphemerides :: (IO a) -> IO a
-withoutEphemerides =
-  bracket_ (setNoEphemeridesPath)
-           (closeEphemerides)
-
--- | Given year, month and day as @Int@ and a time as @Double@, return
--- a single floating point number representing absolute Julian Time.
--- The input date is assumed to be in Gregorian time.
--- More info on this:
--- https://www.astro.com/swisseph/swephprg.htm#_Toc46406824
-julianDay :: Int -> Int -> Int -> Double -> JulianTime
-julianDay year month day hour = realToFrac $ c_swe_julday y m d h gregorian
-  where
-    y = fromIntegral year
-    m = fromIntegral month
-    d = fromIntegral day
-    h = realToFrac hour
-
--- | Given a decimal representation of Julian Time (see @julianDay@),
--- and a @Planet@, returns either the position of that planet at the given time,
--- if available in the ephemeris, or an error.
--- This function is in IO because it _may_ allocate memory/read data beyond
--- its scope, when using ephemeris data. 
-calculateCoordinates :: JulianTime -> Planet -> IO (Either String Coordinates)
-calculateCoordinates time planet =
-    allocaArray 6 $ \coords -> allocaArray 256 $ \errorP -> do
-        iflgret <- c_swe_calc (realToFrac time)
-                              (planetNumber planet)
-                              speed
-                              coords
-                              errorP
-
-        if unCalcFlag iflgret < 0
-            then do
-                msg <- peekCAString errorP
-                return $ Left msg
-            else do
-                result <- peekArray 6 coords
-                return $ Right $ fromList $ map realToFrac result
-
--- | Alias for `calculateCuspsLenient`
-calculateCusps :: JulianTime -> Coordinates -> HouseSystem -> IO CuspsCalculation
-calculateCusps = calculateCuspsLenient
-
--- | Given a decimal representation of Julian Time (see `julianDay`),
--- a set of `Coordinates` (see `mkCoordinates`,) and a `HouseSystem`
--- (most applications use `Placidus`,) return a `CuspsCalculation` with all 12
--- house cusps in that system, and other relevant `Angles`. Notice that certain systems,
--- like `Placidus` and `Koch`, are very likely to fail close to the polar circles; in this
--- and other edge cases, the calculation returns cusps in the `Porphyrius` system.
--- This function is in IO because it _may_ allocate memory/read data beyond
--- its scope, when using ephemeris data. 
-calculateCuspsLenient :: JulianTime -> Coordinates -> HouseSystem -> IO CuspsCalculation
-calculateCuspsLenient time loc sys = allocaArray 13 $ \cusps ->
-    allocaArray 10 $ \ascmc -> do
-        rval <- c_swe_houses (realToFrac time)
-                             (realToFrac $ lat loc)
-                             (realToFrac $ lng loc)
-                             (fromIntegral $ toHouseSystemFlag sys)
-                             cusps
-                             ascmc
-        cuspsL  <- peekArray 13 cusps
-        anglesL <- peekArray 10 ascmc
-        return $ CuspsCalculation
-                  (fromCuspsList $ map realToFrac $ cuspsL) 
-                  (fromAnglesList $ map realToFrac $ anglesL)
-                  (if rval < 0 then Porphyrius else sys)
-
--- | Unlike `calculateCuspsLenient`, return a `Left` value if the required house system
--- couldn't be used to perform the calculations.
-calculateCuspsStrict :: JulianTime -> Coordinates -> HouseSystem -> IO (Either String CuspsCalculation)
-calculateCuspsStrict time loc sys = do
-  calcs@(CuspsCalculation _ _ sys') <- calculateCuspsLenient time loc sys
-  if sys' /= sys then
-    pure $ Left $ "Unable to calculate cusps in the requested house system (used " ++ (show sys') ++ " instead.)"
-  else
-    pure $ Right calcs

--- a/swiss-ephemeris.cabal
+++ b/swiss-ephemeris.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 93624daf4532a29f759103fcb83b46a0d23ea8a3805212214b2812fbfce1e723
+-- hash: 3000345ad0f1743d5d07d502ab8a82e9041a9ce0c3638099da145a5987d1f3a0
 
 name:           swiss-ephemeris
-version:        0.3.1.0
+version:        1.0.0.0
 synopsis:       Haskell bindings for the Swiss Ephemeris C library
 description:    Please see the README on GitHub at <https://github.com/lfborjas/swiss-ephemeris#readme>
 category:       Data, Astrology

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -76,14 +76,14 @@ spec = do
                   }
                 Placidus
 
-        calcs <- calculateCuspsStrict time place Placidus
+        calcs <- calculateCuspsStrict Placidus time place
         calcs `compareCalculations` (Right expectedCalculations) 
 
       it "fails when using a house system that is unable to calculate cusps near the poles" $ do
         let time = julianDay 1989 1 6 0.0
             -- Longyearbyen:
             place = defaultCoordinates {lat = 78.2232, lng = 15.6267}
-        calcs <- calculateCuspsStrict time place Placidus
+        calcs <- calculateCuspsStrict Placidus time place
         calcs `shouldSatisfy` isLeft
 
     describe "calculateCuspsLenient" $ do
@@ -92,7 +92,7 @@ spec = do
             -- Longyearbyen:
             place = defaultCoordinates {lat = 78.2232, lng = 15.6267}
             expected = CuspsCalculation {houseCusps = [190.88156009524067,226.9336677703179,262.9857754453951,299.0378831204723,322.9857754453951,346.9336677703179,10.881560095240673,46.933667770317925,82.98577544539512,119.03788312047234,142.98577544539512,166.9336677703179], angles = Angles {ascendant = 190.88156009524067, mc = 119.03788312047234, armc = 121.17906552074543, vertex = 36.408617337292114, equatorialAscendant = 213.4074315205484, coAscendantKoch = 335.2547300150891, coAscendantMunkasey = 210.81731854391526, polarAscendant = 155.2547300150891}, systemUsed = Porphyrius}
-        calcs <- calculateCuspsLenient time place Placidus
+        calcs <- calculateCuspsLenient Placidus time place
         (systemUsed calcs) `shouldBe` Porphyrius
         (Right calcs) `compareCalculations` (Right expected)
 
@@ -104,13 +104,13 @@ spec = do
         -- > In addition, Sunshine houses may fail, e.g. when required for a date which is outside the time range of our solar ephemeris. Here, also, Porphyry houses will be provided.
         -- from: https://www.astro.com/swisseph/swephprg.htm
         forAll genCuspsQuery $ \((la, lo), time, houseSystem) -> monadicIO $ do
-          calcs <- run $ calculateCusps time (defaultCoordinates{lat = la, lng = lo}) houseSystem
+          calcs <- run $ calculateCusps houseSystem time (defaultCoordinates{lat = la, lng = lo})
           assert $ (systemUsed calcs) `elem` [houseSystem, Porphyrius]
           assert $ (length $ houseCusps calcs) == 12
 
       prop "calculates cusps and angles for points outside of the polar circles in the requested house system, no fallback." $
         forAll genCuspsNonPolarQuery $ \((la, lo), time, houseSystem) -> monadicIO $ do
-          calcs <- run $ calculateCusps time (defaultCoordinates{lat = la, lng = lo}) houseSystem
+          calcs <- run $ calculateCusps houseSystem time (defaultCoordinates{lat = la, lng = lo})
           assert $ (systemUsed calcs) == houseSystem
           assert $ (length $ houseCusps calcs) == 12
 


### PR DESCRIPTION
Closes #1 and closes #2

In preparation for supporting exotic systems like `Gauquelin`, which has 36 "sectors", and through seeing how cusps are usually used, they're now a simple list of doubles. In addition, the house system comes first, allowing users to say:

```haskell
let placidusCusps = calculateCusps Placidus
cuspCalcs <- placidusCusps someTime somePlace
```

Also, a minor improvement, cleaning up the haddocks for the main module.