### PR TITLE
More coordinate functions, better types, some helpers.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## v1.1.0.0 (2020-09-12)
 
+**BREAKING CHANGE:** the `Coordinates` type has been retired, in favor of the more specific
+`GeographicPosition` and `EclipticPosition`. `calculateCoordinates` is now `calculateEclipticPosition`,
+and the `calculateCusps*` family now takes a `GeographicPosition` as part of its inputs.
+
 * Introduces an `Internal` module with types and helpers that this library introduces,
   which are not native to the underlying C library. Import at your own risk! (the "curated"/
   "stable" ones are re-exported by the main module.)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,21 @@
 # Changelog for swiss-ephemeris
 
+## v1.1.0.0 (2020-09-12)
+
+* Introduces an `Internal` module with types and helpers that this library introduces,
+  which are not native to the underlying C library. Import at your own risk! (the "curated"/
+  "stable" ones are re-exported by the main module.)
+  - Deprecates the `Coordinates` type, in favor of `EclipticPosition`.
+* Introduces functions to `calculateEquatorialPosition` and `calculteObliquity` at a given time,
+  as well as types that better convey the different types of positions (`EquatorialPosition`, `ObliquityInformation`).
+* Some astrology helpers: convert between equatorial and ecliptic (and vice-versa,)
+  obtain the Delta Time effective at a given moment, obtain the house position of a given body.
+  (**Note:** the `calculateHousePosition` function is more useful for working near the polar circles or for bodies
+  off of the ecliptic -- the ARMC and obliquity need to be calculated or provided, it's simpler
+  if you already have the cusps: just check which cusps a given longitude falls between -- no need for
+  this function!)
+
+
 ## v1.0.0.0 (2020-09-07)
 
 * Refactor the `calculateCusps` function:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                swiss-ephemeris
-version:             1.0.0.0
+version:             1.1.0.0
 github:              "lfborjas/swiss-ephemeris"
 license:             GPL-2
 author:              "Luis Borjas Reyes"

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -80,7 +80,8 @@ foreign import ccall unsafe "swephexp.h swe_julday"
                  -> CDouble
 
 -- | Calculate the position of a body, given a time in
--- Universal Time.
+-- Universal Time. Note that this is marginally more expensive than
+-- `swe_calc`, but I use this one to keep consistency with `swe_houses`.
 foreign import ccall unsafe "swephexp.h swe_calc_ut"
     c_swe_calc_ut :: CDouble
                   -> PlanetNumber
@@ -119,43 +120,6 @@ foreign import ccall unsafe "swephexp.h swe_cotrans_sp"
                      -> Ptr CDouble -- double[6]: ascension, declination, distance (or viceversa)
                      -> CDouble     -- obliquity of the ecliptic.
                      -> IO ()
-
----
---- NOT IMPLEMENTED IN THE PUBLIC API YET:
---- 
-
--- | Split a given ecliptic longitude into sign (number)
--- degrees, minutes and seconds.
-foreign import ccall unsafe "swephexp.h swe_split_deg"
-    c_swe_split_deg :: CDouble -- longitude
-                    -> SplitDegFlag -- behavior of rounding/assigning to signs
-                    -> Ptr CInt -- degrees
-                    -> Ptr CInt -- minutes
-                    -> Ptr CInt -- seconds
-                    -> Ptr CDouble -- seconds fraction
-                    -> Ptr CInt    -- sign/nakshatra
-                    -> IO ()       -- returns void.
-
--- | Calculate the position of a planet, given a time
--- in Ephemeris Time. swe_calc_ut calls it internally,
--- so if you already have the delta time for other purposes,
--- it'll be slightly faster to call this.
-foreign import ccall unsafe "swephexp.h swe_calc"
-    c_swe_calc :: CDouble -- Ephemeris time. This is Julian + delta time.
-               -> PlanetNumber
-               -> CalcFlag
-               -> Ptr CDouble
-               -> CString
-               -> (IO CalcFlag)
-
--- | Calculate the delta time for a given julian time,
--- delta time + julian time = ephemeris time
--- NOTE: there's also swe_deltat_ex which takes an ephemeris
--- flag explicitly, vs. the current global value.
--- my calculations work in one ephemeris, so this one is suitable.
-foreign import ccall unsafe "swephexp.h swe_deltat"
-    c_swe_deltat :: CDouble -- Julian time
-                 -> (IO CDouble)
 
 -- | Calculate the sidereal time for a given julian time.
 -- NOTE: there's also swe_sidtime0 which requires obliquity

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -121,6 +121,31 @@ foreign import ccall unsafe "swephexp.h swe_cotrans_sp"
                      -> CDouble     -- obliquity of the ecliptic.
                      -> IO ()
 
+---
+--- NOT IMPLEMENTED IN THE PUBLIC API YET:
+--- 
+
+-- | Split a given ecliptic longitude into sign (number)
+-- degrees, minutes and seconds.
+foreign import ccall unsafe "swephexp.h swe_split_deg"
+    c_swe_split_deg :: CDouble -- longitude
+                    -> SplitDegFlag -- behavior of rounding/assigning to signs
+                    -> Ptr CInt -- degrees
+                    -> Ptr CInt -- minutes
+                    -> Ptr CInt -- seconds
+                    -> Ptr CDouble -- seconds fraction
+                    -> Ptr CInt    -- sign/nakshatra
+                    -> IO ()       -- returns void.
+
+-- | Calculate the delta time for a given julian time,
+-- delta time + julian time = ephemeris time
+-- NOTE: there's also swe_deltat_ex which takes an ephemeris
+-- flag explicitly, vs. the current global value.
+-- my calculations work in one ephemeris, so this one is suitable.
+foreign import ccall unsafe "swephexp.h swe_deltat"
+    c_swe_deltat :: CDouble -- Julian time
+                 -> (IO CDouble)
+
 -- | Calculate the sidereal time for a given julian time.
 -- NOTE: there's also swe_sidtime0 which requires obliquity
 -- and nutation, this one computes them internally.

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -17,6 +17,9 @@ newtype GregFlag = GregFlag
 newtype CalcFlag = CalcFlag
   { unCalcFlag :: CInt } deriving (Eq, Show)
 
+newtype SplitDegFlag = SplitDegFlag
+  { unSplitDegFlag :: CInt } deriving (Eq, Show)
+
 -- following:
 -- https://en.wikibooks.org/wiki/Haskell/FFI#Enumerations
 
@@ -37,6 +40,7 @@ newtype CalcFlag = CalcFlag
  , oscuApog = SE_OSCU_APOG
  , earth    = SE_EARTH
  , chiron = SE_CHIRON
+ , specialEclNut = SE_ECL_NUT
  }
 
 #{enum GregFlag, GregFlag
@@ -44,13 +48,22 @@ newtype CalcFlag = CalcFlag
  , gregorian = SE_GREG_CAL
  }
 
+-- there are _many_ more, see `swephexp.h:186-215`
 #{enum CalcFlag, CalcFlag
  , speed = SEFLG_SPEED
  , swissEph = SEFLG_SWIEPH
  , equatorialPositions = SEFLG_EQUATORIAL
  }
 
--- functions to make the "mini" example work:
+#{enum SplitDegFlag, SplitDegFlag
+ , splitRoundSec = SE_SPLIT_DEG_ROUND_SEC
+ , splitRoundMin = SE_SPLIT_DEG_ROUND_MIN
+ , splitRoundDeg = SE_SPLIT_DEG_ROUND_DEG
+ , splitZodiacal = SE_SPLIT_DEG_ZODIACAL
+ , splitNakshatra = SE_SPLIT_DEG_NAKSHATRA
+ , splitKeepSign  = SE_SPLIT_DEG_KEEP_SIGN
+ , splitKeepDeg   = SE_SPLIT_DEG_KEEP_DEG
+ }
 
 foreign import ccall unsafe "swephexp.h swe_set_ephe_path"
     c_swe_set_ephe_path :: CString -> IO ()
@@ -66,14 +79,20 @@ foreign import ccall unsafe "swephexp.h swe_julday"
                  -> GregFlag
                  -> CDouble
 
+-- | Calculate the position of a body, given a time in
+-- Universal Time.
 foreign import ccall unsafe "swephexp.h swe_calc_ut"
-    c_swe_calc :: CDouble
-               -> PlanetNumber
-               -> CalcFlag
-               -> Ptr CDouble
-               -> CString
-               -> (IO CalcFlag)
+    c_swe_calc_ut :: CDouble
+                  -> PlanetNumber
+                  -> CalcFlag
+                  -> Ptr CDouble
+                  -> CString
+                  -> (IO CalcFlag)
 
+-- | Get the house cusps and other relevant angles for
+-- a given time and place. Note that there's also a
+-- @swe_houses_armc@ if one happens to have the ARMC
+-- and the ecliptic obliquity handy from other calculations.
 foreign import ccall unsafe "swephexp.h swe_houses"
     c_swe_houses :: CDouble -- in fact, a Julian day "Number"
                  -> CDouble -- Lat
@@ -82,3 +101,54 @@ foreign import ccall unsafe "swephexp.h swe_houses"
                  -> Ptr CDouble -- cusps, 13 doubles (or 37 in system G)
                  -> Ptr CDouble -- ascmc, 10 doubles
                  -> (IO CInt)
+
+-- | Calculate the position of a planet, given a time
+-- in Ephemeris Time. swe_calc_ut calls it internally,
+-- so if you already have the delta time for other purposes,
+-- it'll be slightly faster to call this.
+foreign import ccall unsafe "swephexp.h swe_calc"
+    c_swe_calc :: CDouble -- Ephemeris time. This is Julian + delta time.
+               -> PlanetNumber
+               -> CalcFlag
+               -> Ptr CDouble
+               -> CString
+               -> (IO CalcFlag)
+
+-- | Calculate the delta time for a given julian time,
+-- delta time + julian time = ephemeris time
+-- NOTE: there's also swe_deltat_ex which takes an ephemeris
+-- flag explicitly, vs. the current global value.
+-- my calculations work in one ephemeris, so this one is suitable.
+foreign import ccall unsafe "swephexp.h swe_deltat"
+    c_swe_deltat :: CDouble -- Julian time
+                 -> (IO CDouble)
+
+-- | Calculate the sidereal time for a given julian time.
+-- NOTE: there's also swe_sidtime0 which requires obliquity
+-- and nutation, this one computes them internally.
+foreign import ccall unsafe "swephexp.h swe_sidtime"
+    c_swe_sidtime :: CDouble -- Julian time
+                  -> (IO CDouble)
+
+-- | Calculate the house a planet is in. Takes into account
+-- obliquity of the ecliptic. Works for all house systems, 
+-- except Koch.
+foreign import ccall unsafe "swephexp.h swe_house_pos"
+    c_swe_house_pos :: CDouble -- ARMC
+                    -> CDouble -- Geographical latitude
+                    -> CDouble -- Obliquity
+                    -> CInt    -- house system
+                    -> Ptr CDouble -- double[2], long/lat of body.
+                    -> CString     -- char[256] for errors.
+
+-- | Split a given ecliptic longitude into sign (number)
+-- degrees, minutes and seconds.
+foreign import ccall unsafe "swephexp.h swe_split_deg"
+    c_swe_split_deg :: CDouble -- longitude
+                    -> SplitDegFlag -- behavior of rounding/assigning to signs
+                    -> Ptr CInt -- degrees
+                    -> Ptr CInt -- minutes
+                    -> Ptr CInt -- seconds
+                    -> Ptr CDouble -- seconds fraction
+                    -> Ptr CInt    -- sign/nakshatra
+                    -> IO ()       -- returns void.

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -114,14 +114,6 @@ foreign import ccall unsafe "swephexp.h swe_house_pos"
                     -> CString     -- char[256] for errors.
                     -> (IO CDouble)
 
--- | Convert between coordinate systems: positive obliquity for equ -> ecliptic,
--- negative obliquity for ecliptic -> equ
-foreign import ccall unsafe "swephexp.h swe_cotrans"
-    c_swe_cotrans :: Ptr CDouble -- double[3]: lng, lat, distance
-                  -> Ptr CDouble -- double[3]: ascension, declination, distance (or viceversa)
-                  -> CDouble     -- obliquity of the ecliptic.
-                  -> IO ()
-
 foreign import ccall unsafe "swephexp.h swe_cotrans_sp"
     c_swe_cotrans_sp :: Ptr CDouble -- double[6]: lng, lat, distance
                      -> Ptr CDouble -- double[6]: ascension, declination, distance (or viceversa)

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -122,6 +122,12 @@ foreign import ccall unsafe "swephexp.h swe_cotrans"
                   -> CDouble     -- obliquity of the ecliptic.
                   -> IO ()
 
+foreign import ccall unsafe "swephexp.h swe_cotrans_sp"
+    c_swe_cotrans_sp :: Ptr CDouble -- double[6]: lng, lat, distance
+                     -> Ptr CDouble -- double[6]: ascension, declination, distance (or viceversa)
+                     -> CDouble     -- obliquity of the ecliptic.
+                     -> IO ()
+
 ---
 --- NOT IMPLEMENTED IN THE PUBLIC API YET:
 --- 

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -1,4 +1,12 @@
 {-# LANGUAGE CPP, ForeignFunctionInterface #-}
+{-| 
+Module: Foreign.SwissEphemeris
+Description: Declarations of bindings to the underlying C library. Import at your own risk!
+
+Exposes very low-level FFI bindings to the C library. Use the @SwissEphemeris@ module and its more
+Haskell-friendly exports.
+-}
+
 
 module Foreign.SwissEphemeris where
 
@@ -81,7 +89,7 @@ foreign import ccall unsafe "swephexp.h swe_julday"
 
 -- | Calculate the position of a body, given a time in
 -- Universal Time. Note that this is marginally more expensive than
--- `swe_calc`, but I use this one to keep consistency with `swe_houses`.
+-- @swe_calc@, but I use this one to keep consistency with @swe_houses@.
 foreign import ccall unsafe "swephexp.h swe_calc_ut"
     c_swe_calc_ut :: CDouble
                   -> PlanetNumber
@@ -115,6 +123,7 @@ foreign import ccall unsafe "swephexp.h swe_house_pos"
                     -> CString     -- char[256] for errors.
                     -> (IO CDouble)
 
+-- | Low-level function to translate between coordinate systems, with speed position included.
 foreign import ccall unsafe "swephexp.h swe_cotrans_sp"
     c_swe_cotrans_sp :: Ptr CDouble -- double[6]: lng, lat, distance
                      -> Ptr CDouble -- double[6]: ascension, declination, distance (or viceversa)
@@ -135,7 +144,7 @@ foreign import ccall unsafe "swephexp.h swe_split_deg"
 
 -- | Calculate the delta time for a given julian time,
 -- delta time + julian time = ephemeris time
--- NOTE: there's also swe_deltat_ex which takes an ephemeris
+-- NOTE: there's also @swe_deltat_ex@ which takes an ephemeris
 -- flag explicitly, vs. the current global value.
 -- my calculations work in one ephemeris, so this one is suitable.
 foreign import ccall unsafe "swephexp.h swe_deltat"
@@ -143,15 +152,13 @@ foreign import ccall unsafe "swephexp.h swe_deltat"
                  -> (IO CDouble)
 
 -- | Calculate the sidereal time for a given julian time.
--- NOTE: there's also swe_sidtime0 which requires obliquity
+-- NOTE: there's also @swe_sidtime0@ which requires obliquity
 -- and nutation, this one computes them internally.
 foreign import ccall unsafe "swephexp.h swe_sidtime"
     c_swe_sidtime :: CDouble -- Julian time
                    -> (IO CDouble)
 
--- | Calculate the sidereal time for a given julian time.
--- NOTE: there's also swe_sidtime0 which requires obliquity
--- and nutation, this one computes them internally.
+-- | Calculate the sidereal time for a given julian time, obliquity and nutation.
 foreign import ccall unsafe "swephexp.h swe_sidtime0"
     c_swe_sidtime0 :: CDouble -- Julian time
                    -> CDouble -- obliquity

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -114,6 +114,18 @@ foreign import ccall unsafe "swephexp.h swe_house_pos"
                     -> CString     -- char[256] for errors.
                     -> (IO CDouble)
 
+-- | Convert between coordinate systems: positive obliquity for equ -> ecliptic,
+-- negative obliquity for ecliptic -> equ
+foreign import ccall unsafe "swephexp.h swe_cotrans"
+    c_swe_cotrans :: Ptr CDouble -- double[3]: lng, lat, distance
+                  -> Ptr CDouble -- double[3]: ascension, declination, distance (or viceversa)
+                  -> CDouble     -- obliquity of the ecliptic.
+                  -> IO ()
+
+---
+--- NOT IMPLEMENTED IN THE PUBLIC API YET:
+--- 
+
 -- | Split a given ecliptic longitude into sign (number)
 -- degrees, minutes and seconds.
 foreign import ccall unsafe "swephexp.h swe_split_deg"
@@ -125,10 +137,6 @@ foreign import ccall unsafe "swephexp.h swe_split_deg"
                     -> Ptr CDouble -- seconds fraction
                     -> Ptr CInt    -- sign/nakshatra
                     -> IO ()       -- returns void.
-
----
---- NOT IMPLEMENTED IN THE PUBLIC API YET:
---- 
 
 -- | Calculate the position of a planet, given a time
 -- in Ephemeris Time. swe_calc_ut calls it internally,

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -102,6 +102,34 @@ foreign import ccall unsafe "swephexp.h swe_houses"
                  -> Ptr CDouble -- ascmc, 10 doubles
                  -> (IO CInt)
 
+-- | Calculate the house a planet is in. Takes into account
+-- obliquity of the ecliptic. Works for all house systems, 
+-- except Koch.
+foreign import ccall unsafe "swephexp.h swe_house_pos"
+    c_swe_house_pos :: CDouble -- ARMC
+                    -> CDouble -- Geographical latitude
+                    -> CDouble -- Obliquity
+                    -> CInt    -- house system
+                    -> Ptr CDouble -- double[2], long/lat of body.
+                    -> CString     -- char[256] for errors.
+                    -> (IO CDouble)
+
+-- | Split a given ecliptic longitude into sign (number)
+-- degrees, minutes and seconds.
+foreign import ccall unsafe "swephexp.h swe_split_deg"
+    c_swe_split_deg :: CDouble -- longitude
+                    -> SplitDegFlag -- behavior of rounding/assigning to signs
+                    -> Ptr CInt -- degrees
+                    -> Ptr CInt -- minutes
+                    -> Ptr CInt -- seconds
+                    -> Ptr CDouble -- seconds fraction
+                    -> Ptr CInt    -- sign/nakshatra
+                    -> IO ()       -- returns void.
+
+---
+--- NOT IMPLEMENTED IN THE PUBLIC API YET:
+--- 
+
 -- | Calculate the position of a planet, given a time
 -- in Ephemeris Time. swe_calc_ut calls it internally,
 -- so if you already have the delta time for other purposes,
@@ -128,27 +156,13 @@ foreign import ccall unsafe "swephexp.h swe_deltat"
 -- and nutation, this one computes them internally.
 foreign import ccall unsafe "swephexp.h swe_sidtime"
     c_swe_sidtime :: CDouble -- Julian time
-                  -> (IO CDouble)
+                   -> (IO CDouble)
 
--- | Calculate the house a planet is in. Takes into account
--- obliquity of the ecliptic. Works for all house systems, 
--- except Koch.
-foreign import ccall unsafe "swephexp.h swe_house_pos"
-    c_swe_house_pos :: CDouble -- ARMC
-                    -> CDouble -- Geographical latitude
-                    -> CDouble -- Obliquity
-                    -> CInt    -- house system
-                    -> Ptr CDouble -- double[2], long/lat of body.
-                    -> CString     -- char[256] for errors.
-
--- | Split a given ecliptic longitude into sign (number)
--- degrees, minutes and seconds.
-foreign import ccall unsafe "swephexp.h swe_split_deg"
-    c_swe_split_deg :: CDouble -- longitude
-                    -> SplitDegFlag -- behavior of rounding/assigning to signs
-                    -> Ptr CInt -- degrees
-                    -> Ptr CInt -- minutes
-                    -> Ptr CInt -- seconds
-                    -> Ptr CDouble -- seconds fraction
-                    -> Ptr CInt    -- sign/nakshatra
-                    -> IO ()       -- returns void.
+-- | Calculate the sidereal time for a given julian time.
+-- NOTE: there's also swe_sidtime0 which requires obliquity
+-- and nutation, this one computes them internally.
+foreign import ccall unsafe "swephexp.h swe_sidtime0"
+    c_swe_sidtime0 :: CDouble -- Julian time
+                   -> CDouble -- obliquity
+                   -> CDouble -- nutation
+                   -> (IO CDouble)

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -121,10 +121,6 @@ foreign import ccall unsafe "swephexp.h swe_cotrans_sp"
                      -> CDouble     -- obliquity of the ecliptic.
                      -> IO ()
 
----
---- NOT IMPLEMENTED IN THE PUBLIC API YET:
---- 
-
 -- | Split a given ecliptic longitude into sign (number)
 -- degrees, minutes and seconds.
 foreign import ccall unsafe "swephexp.h swe_split_deg"

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -140,7 +140,7 @@ calculateEclipticPosition time planet = do
   return $ fmap coordinatesFromList rawCoords
 
 -- | Obtain equatorial position (includes declination) of a planet.
--- If you've called `calculateCoordinates` in your code, this is a very cheap call, as the data
+-- If you've called `calculateEclipticPosition` in your code, this is a very cheap call, as the data
 -- is already available to the C code.
 calculateEquatorialPosition :: JulianTime -> Planet -> IO (Either String EquatorialPosition)
 calculateEquatorialPosition time planet = do
@@ -208,7 +208,7 @@ calculateCusps :: HouseSystem -> JulianTime -> GeographicPosition -> IO CuspsCal
 calculateCusps = calculateCuspsLenient
 
 -- | Given a decimal representation of Julian Time (see `julianDay`),
--- a set of `Coordinates` (see `mkCoordinates`,) and a `HouseSystem`
+-- a `GeographicPosition` and a `HouseSystem`
 -- (most applications use `Placidus`,) return a `CuspsCalculation` with all
 -- house cusps in that system, and other relevant `Angles`.
 -- Notice that certain systems,
@@ -259,7 +259,7 @@ calculateCuspsStrict sys time loc = do
 -- see <https://groups.io/g/swisseph/message/4052>
 -- NOTES: for the Koch system, this is likely to fail, or return counterintuitive
 -- results. Also, we're doing a bit of a funky conversion between sidereal time and
--- ARMC, if you `calculateCusps`, the correct ARMC will be present in
+-- ARMC, if you `calculateCusps`, the correct `armc` will be present in the returned `Angles`
 calculateHousePositionSimple :: HouseSystem -> JulianTime -> GeographicPosition -> EclipticPosition -> IO (Either String HousePosition)
 calculateHousePositionSimple sys time loc pos = do
   obliquityAndNutation <- calculateObliquity time
@@ -324,6 +324,8 @@ deltaTime jt = do
   deltaT <- c_swe_deltat . realToFrac . unJulianTime $ jt
   return $ realToFrac deltaT
 
+-- | Given a longitude, return the degrees it's from its nearest sign,
+-- minutes, seconds and seconds fraction.
 splitDegreesZodiac :: Double -> LongitudeComponents
 splitDegreesZodiac d =
   LongitudeComponents (Just $ toEnum z) deg m s sf
@@ -331,6 +333,7 @@ splitDegreesZodiac d =
     (z, deg, m, s, sf) = splitDegrees' options d
     options = mkSplitDegOptions $ defaultSplitDegOptions ++ [splitZodiacal]
 
+-- | Given a longitude, return the degrees from zero, minutes, seconds and seconds fraction.
 splitDegrees :: Double -> LongitudeComponents
 splitDegrees d =
   LongitudeComponents Nothing deg m s sf

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -161,25 +161,25 @@ calculateCoordinates' options time planet =
 eclipticToEquatorial :: ObliquityAndNutation -> EclipticPosition -> EquatorialPosition
 eclipticToEquatorial oAndN ecliptic =
   let obliquityLn = eclipticObliquity oAndN
-      eclipticPos = [lng ecliptic, lat ecliptic, distance ecliptic]
-      (asc:dec:dist:_)  = coordinateTransform' (negate obliquityLn) eclipticPos
+      eclipticPos = eclipticToList ecliptic
+      transformed = coordinateTransform' (negate obliquityLn) eclipticPos
   in
-    EquatorialPosition asc dec dist 0 0 0
+    equatorialFromList transformed
 
 equatorialToEcliptic :: ObliquityAndNutation -> EquatorialPosition -> EclipticPosition
 equatorialToEcliptic oAndN equatorial =
   let obliquityLn   = eclipticObliquity oAndN
-      equatorialPos = [rightAscension equatorial, declination equatorial, eqDistance equatorial]
-      (ln:lt:dist:_)  = coordinateTransform' obliquityLn equatorialPos
+      equatorialPos = equatorialToList equatorial
+      transformed   = coordinateTransform' obliquityLn equatorialPos
   in
-    EclipticPosition ln lt dist 0 0 0
+    eclipticFromList transformed
 
 coordinateTransform' :: Double -> [Double] -> [Double]
 coordinateTransform' obliquity ins =
   unsafePerformIO $ do
-    withArray (map realToFrac ins) $ \xpo -> allocaArray 3 $ \xpn -> do
-      _ <- c_swe_cotrans xpo xpn (realToFrac obliquity)
-      result <- peekArray 3 xpn
+    withArray (map realToFrac ins) $ \xpo -> allocaArray 6 $ \xpn -> do
+      _ <- c_swe_cotrans_sp xpo xpn (realToFrac obliquity)
+      result <- peekArray 6 xpn
       return $ map realToFrac result
 
 -- | Alias for `calculateCuspsLenient`

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -177,7 +177,7 @@ equatorialToEcliptic oAndN equatorial =
 coordinateTransform' :: Double -> [Double] -> [Double]
 coordinateTransform' obliquity ins =
   unsafePerformIO $ do
-    withArray (map realToFrac ins) $ \xpo -> allocaArray 6 $ \xpn -> do
+    withArray (map realToFrac $ take 6 ins) $ \xpo -> allocaArray 6 $ \xpn -> do
       _ <- c_swe_cotrans_sp xpo xpn (realToFrac obliquity)
       result <- peekArray 6 xpn
       return $ map realToFrac result

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -60,6 +60,7 @@ module SwissEphemeris
     calculateHousePositionSimple,
     -- utilities for time calculations:
     julianDay,
+    deltaTime,
   )
 where
 
@@ -307,3 +308,14 @@ calculateSiderealTime jt on = do
       nut = realToFrac $ nutationLongitude on
   sidTime <- c_swe_sidtime0 (realToFrac . unJulianTime $ jt) obliq nut
   return $ SiderealTime $ realToFrac sidTime
+
+-- | Given a `JulianTime` (based on a UniversalTime), calculate the delta
+-- between it and "true time":
+-- See <https://www.astro.com/swisseph/swisseph.htm#_Toc46391727 7. Delta T>
+-- It relies on ephemeris data being open, and as such belongs in IO.
+-- /NOTE:/ this could be used to create a JulianTime -> EphemerisTime
+-- function to send down to @swe_calc@, if we choose to port that one.
+deltaTime :: JulianTime -> IO Double
+deltaTime jt = do
+  deltaT <- c_swe_deltat . realToFrac . unJulianTime $ jt
+  return $ realToFrac deltaT

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -21,8 +21,6 @@ module SwissEphemeris
     JulianTime,
     SiderealTime,
     HouseCusp,
-    -- deprecated type!
-    Coordinates,
     -- fundamental enumerations
     Planet (..),
     HouseSystem (..),
@@ -44,7 +42,6 @@ module SwissEphemeris
     withEphemerides,
     withoutEphemerides,
     -- core calculations
-    calculateCoordinates,
     calculateEclipticPosition,
     calculateEquatorialPosition,
     calculateObliquity,
@@ -121,13 +118,6 @@ julianDay year month day hour = JulianTime $ realToFrac $ c_swe_julday y m d h g
     m = fromIntegral month
     d = fromIntegral day
     h = realToFrac hour
-
-{-# DEPRECATED calculateCoordinates "Use calculateEclipticPosition or calculateEquatorialPosition." #-}
-
--- | Alias for `calculateEclipticPosition`, since it's the most common
--- position calculation.
-calculateCoordinates :: JulianTime -> Planet -> IO (Either String Coordinates)
-calculateCoordinates = calculateEclipticPosition
 
 -- | Given `JulianTime` (see `julianDay`),
 -- and a `Planet`, returns either the position of that planet at the given time,

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -77,6 +77,7 @@ newtype ARMC = ARMC {unArmc :: Double}
 -- and <https://www.astro.com/swisseph/swisseph.htm#_Toc46391705 6.2 Astrological house systems>
 type HouseCusp = Double
 
+
 -- | Position data for a celestial body, includes rotational speeds.
 -- see:
 -- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847837 3.4 Position and speed>

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -73,7 +73,7 @@ data ZodiacSignName
 -- | Represents an instant in Julian time.
 -- see:
 -- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847871 8. Date and time conversion functions>
--- also cf. `julianDay`
+-- also cf. @julianDay@
 newtype JulianTime = JulianTime {unJulianTime :: Double}
   deriving (Show, Eq, Ord)
 
@@ -102,6 +102,8 @@ data EclipticPosition = EclipticPosition
 
 {-# DEPRECATED Coordinates "This was an ambiguous type, use EclipticPosition for positions of celestial bodies, or GeographicPosition for a point on Earth." #-}
 
+-- | Deprecated type alias, used to mean `EclipticPosition` before we introduced other
+-- types of positions.
 type Coordinates = EclipticPosition
 
 -- | Represents a point on Earth, with negative values

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -1,20 +1,18 @@
-{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE DeriveGeneric #-}
 
-{-|
-Module: SwissEphemeris.Internal
-Description: helper functions and types, not for public consumption.
-
-The types defined here are exported publicly for convenience, but at least in versions <= 2.x, they're likely to evolve.
--}
-
+-- |
+-- Module: SwissEphemeris.Internal
+-- Description: helper functions and types, not for public consumption.
+--
+-- The types defined here are exported publicly for convenience, but at least in versions <= 2.x, they're likely to evolve.
 module SwissEphemeris.Internal where
 
-import Foreign.SwissEphemeris
 import Data.Bits
-import           GHC.Generics
-import Foreign.C.Types
-import Foreign (Int32)
 import Data.Char (ord)
+import Foreign (Int32)
+import Foreign.C.Types
+import Foreign.SwissEphemeris
+import GHC.Generics
 
 -- | All bodies for which a position can be calculated. Covers planets
 -- in the solar system, points between the Earth and the Moon, and
@@ -22,138 +20,151 @@ import Data.Char (ord)
 -- ephemerides data is available for others.)
 -- More at <https://www.astro.com/swisseph/swisseph.htm#_Toc46391648 2.1 Planetary and lunar ephemerides>
 -- and <https://www.astro.com/swisseph/swephprg.htm#_Toc49847827 3.2 bodies>
-data Planet = Sun
-            | Moon
-            | Mercury
-            | Venus
-            | Mars
-            | Jupiter
-            | Saturn
-            | Uranus
-            | Neptune
-            | Pluto
-            | MeanNode
-            | TrueNode
-            | MeanApog
-            | OscuApog
-            | Earth
-            | Chiron
-            deriving (Show, Eq, Ord, Enum, Generic)
+data Planet
+  = Sun
+  | Moon
+  | Mercury
+  | Venus
+  | Mars
+  | Jupiter
+  | Saturn
+  | Uranus
+  | Neptune
+  | Pluto
+  | MeanNode
+  | TrueNode
+  | MeanApog
+  | OscuApog
+  | Earth
+  | Chiron
+  deriving (Show, Eq, Ord, Enum, Generic)
 
 -- | The major house systems. The underlying library supports many more, including the
 -- 36-cusp outlier Gauquelin.
 -- More info at <https://www.astro.com/swisseph/swisseph.htm#_Toc46391705 6.2 Astrological house systems>
 -- and <https://www.astro.com/swisseph/swephprg.htm#_Toc49847888 14. House cusp calculation>
-data HouseSystem = Placidus
-                 | Koch
-                 | Porphyrius
-                 | Regiomontanus
-                 | Campanus
-                 | Equal
-                 | WholeSign
-                 deriving (Show, Eq, Ord, Enum, Generic)
+data HouseSystem
+  = Placidus
+  | Koch
+  | Porphyrius
+  | Regiomontanus
+  | Campanus
+  | Equal
+  | WholeSign
+  deriving (Show, Eq, Ord, Enum, Generic)
+
+-- | Represents western zodiac signs. Unless otherwise stated, they correspond to tropical
+-- divisions of the ecliptic, vs. the actual constellations.
+data ZodiacSignName
+  = Aries
+  | Taurus
+  | Gemini
+  | Cancer
+  | Leo
+  | Virgo
+  | Libra
+  | Scorpio
+  | Sagittarius
+  | Capricorn
+  | Aquarius
+  | Pisces
+  deriving (Eq, Show, Enum, Generic)
 
 -- | Represents an instant in Julian time.
 -- see:
 -- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847871 8. Date and time conversion functions>
 -- also cf. `julianDay`
-type JulianTime = Double
+newtype JulianTime = JulianTime {unJulianTime :: Double}
+  deriving (Show, Eq, Ord)
+
+-- | Represents an instant in sidereal time
 newtype SiderealTime = SiderealTime {unSidereal :: Double}
-    deriving (Show, Eq)
+  deriving (Show, Eq, Ord)
 
--- | Convert tropical sidereal time to an ARMC relative to a given longitude
--- this is not explained in the SWE docs, I pulled it from:
---   armc = swe_degnorm(swe_sidtime0(tjd_ut, eps + nutlo[1], nutlo[0]) * 15 + geolon);
--- (line 144 of swehouse.c, part of swe_houses)
-sidToArmc :: SiderealTime -> Double -> ARMC
-sidToArmc s l = ARMC $ (unSidereal s) * 15 + l
-
-newtype ARMC = ARMC {unArmc :: Double}
-    deriving (Show, Eq)
-
--- | The cusp of a given "house" or "sector"
+-- | The cusp of a given "house" or "sector". It is an ecliptic longitude.
 -- see:
 -- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847888 14.1 House cusp calculation>
 -- and <https://www.astro.com/swisseph/swisseph.htm#_Toc46391705 6.2 Astrological house systems>
 type HouseCusp = Double
 
-
--- | Position data for a celestial body, includes rotational speeds.
+-- | Position data for a celestial body on the ecliptic, includes rotational speeds.
 -- see:
 -- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847837 3.4 Position and speed>
 data EclipticPosition = EclipticPosition
-  {
-    lng :: Double
-  , lat :: Double
-  , distance :: Double -- in AU
-  , lngSpeed :: Double -- deg/day
-  , latSpeed :: Double -- deg/day
-  , distSpeed :: Double -- deg/day
-  } deriving (Show, Eq, Generic)
+  { lng :: Double,
+    lat :: Double,
+    distance :: Double, -- in AU
+    lngSpeed :: Double, -- deg/day
+    latSpeed :: Double, -- deg/day
+    distSpeed :: Double -- deg/day
+  }
+  deriving (Show, Eq, Generic)
+
+{-# DEPRECATED Coordinates "This was an ambiguous type, use EclipticPosition for positions of celestial bodies, or GeographicPosition for a point on Earth." #-}
 
 type Coordinates = EclipticPosition
 
+-- | Represents a point on Earth, with negative values
+-- for latitude meaning South, and negative values for longitude
+-- meaning West. No speed information is included (or needed,)
+-- because all calculations are geocentric.
+data GeographicPosition = GeographicPosition
+  { geoLat :: Double,
+    geoLng :: Double
+  }
+  deriving (Show, Eq, Generic)
+
+-- | Represents a position on the celestial sphere,
+-- with speed information included.
 data EquatorialPosition = EquatorialPosition
-  {
-    rightAscension :: Double
-  , declination :: Double
-  , eqDistance  :: Double -- same as distance in `EclipticPosition`, uses AU
-  , ascensionSpeed :: Double -- deg/day
-  , declinationSpeed :: Double -- deg/day
-  , eqDistanceSpeed :: Double -- deg/day
-  } deriving (Show, Eq, Generic)
+  { rightAscension :: Double,
+    declination :: Double,
+    eqDistance :: Double, -- same as distance in `EclipticPosition`, uses AU
+    ascensionSpeed :: Double, -- deg/day
+    declinationSpeed :: Double, -- deg/day
+    eqDistanceSpeed :: Double -- deg/day
+  }
+  deriving (Show, Eq, Generic)
 
-data ObliquityAndNutation = ObliquityAndNutation
-  {
-    eclipticObliquity :: Double
-  , eclipticMeanObliquity :: Double
-  , nutationLongitude :: Double
-  , nutationObliquity :: Double
-  } deriving (Show, Eq, Generic)
+-- | Includes the obliquity of the ecliptic, the Nutation as longitude
+-- as well as mean values.
+data ObliquityInformation = ObliquityInformation
+  { eclipticObliquity :: Double,
+    eclipticMeanObliquity :: Double,
+    nutationLongitude :: Double,
+    nutationObliquity :: Double
+  }
+  deriving (Show, Eq, Generic)
 
--- | Default coordinates with all zeros -- when you don't care about/know the velocities,
--- which would be the case for most inputs (though most outputs /will/ include them.)
--- Usually you'll set only lat and lng (e.g. @defaultEclipticPosition{lat = 1.4, lng = 4.1}@)
--- when using it as an input for another function.
-defaultEclipticPosition :: EclipticPosition
-defaultEclipticPosition = EclipticPosition 0 0 0 0 0 0
-
--- | Constructor alias of `defaultEclipticPosition`, since it's used a lot in that role.
-mkEclipticPosition :: EclipticPosition
-mkEclipticPosition = defaultEclipticPosition
-
--- TODO: need a new type: GeographicPosition, with only lat and lng.
-mkCoordinates :: EclipticPosition
-mkCoordinates = mkEclipticPosition
+-- | The house a celestial body is in.
+data HousePosition = HousePosition
+  { houseNumber :: Int,
+    houseCuspDistance :: Double
+  }
+  deriving (Show, Eq, Generic)
 
 -- | Relevant angles: ascendant and MC, plus other "exotic" ones:
 -- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847890 14. House cusp calculation>
 data Angles = Angles
-  {
-    ascendant :: Double
-  , mc :: Double
-  , armc :: Double
-  , vertex :: Double
-  , equatorialAscendant :: Double
-  , coAscendantKoch :: Double
-  , coAscendantMunkasey :: Double
-  , polarAscendant :: Double
-  } deriving (Show, Eq, Generic)
+  { ascendant :: Double,
+    mc :: Double,
+    armc :: Double,
+    vertex :: Double,
+    equatorialAscendant :: Double,
+    coAscendantKoch :: Double,
+    coAscendantMunkasey :: Double,
+    polarAscendant :: Double
+  }
+  deriving (Show, Eq, Generic)
 
 -- | Result of calculating the cusps for a given event; will include a list of
 -- cusps (most systems use 12 cusps, Gauquelin uses 36.)
 data CuspsCalculation = CuspsCalculation
-  {
-    houseCusps :: [HouseCusp]
-  , angles :: Angles
-  , systemUsed :: HouseSystem
-  } deriving (Show, Eq, Generic)
-
-data HousePosition = HousePosition
-    {
-        houseNumber :: Int
-    ,   houseCuspDistance :: Double
-    } deriving (Show, Eq, Generic)
+  { houseCusps :: [HouseCusp],
+    angles :: Angles,
+    systemUsed :: HouseSystem
+  }
+  deriving (Show, Eq, Generic)
 
 -- folders for bitwise flags, and some opinionated defaults.
 
@@ -161,18 +172,18 @@ mkCalculationOptions :: [CalcFlag] -> CalcFlag
 mkCalculationOptions = CalcFlag . foldr ((.|.) . unCalcFlag) 0
 
 defaultCalculationOptions :: [CalcFlag]
-defaultCalculationOptions =  [speed, swissEph]
+defaultCalculationOptions = [speed, swissEph]
 
 mkRoundingOptions :: [SplitDegFlag] -> SplitDegFlag
 mkRoundingOptions = SplitDegFlag . foldr ((.|.) . unSplitDegFlag) 0
 
 defaultRoundingOptions :: [SplitDegFlag]
-defaultRoundingOptions = 
-    [ splitKeepDeg  -- don't round up to the next degree
-    , splitKeepSign -- don't round up to the next sign
-    , splitZodiacal -- reference zodiacal signs
-    , splitRoundSec -- don't need second fractions.
-    ]
+defaultRoundingOptions =
+  [ splitKeepDeg, -- don't round up to the next degree
+    splitKeepSign, -- don't round up to the next sign
+    splitZodiacal, -- reference zodiacal signs
+    splitRoundSec -- don't need second fractions.
+  ]
 
 -- helpers
 
@@ -182,13 +193,13 @@ defaultRoundingOptions =
 -- codes for specific characters (!)
 -- documentation at: https://www.astro.com/swisseph/swephprg.htm#_Toc19111265
 toHouseSystemFlag :: HouseSystem -> Int
-toHouseSystemFlag Placidus      = ord 'P'
-toHouseSystemFlag Koch          = ord 'K'
-toHouseSystemFlag Porphyrius    = ord 'O'
+toHouseSystemFlag Placidus = ord 'P'
+toHouseSystemFlag Koch = ord 'K'
+toHouseSystemFlag Porphyrius = ord 'O'
 toHouseSystemFlag Regiomontanus = ord 'R'
-toHouseSystemFlag Campanus      = ord 'C'
-toHouseSystemFlag Equal         = ord 'A'
-toHouseSystemFlag WholeSign     = ord 'W'
+toHouseSystemFlag Campanus = ord 'C'
+toHouseSystemFlag Equal = ord 'A'
+toHouseSystemFlag WholeSign = ord 'W'
 
 coordinatesFromList :: [Double] -> EclipticPosition
 -- N.B. note that for some reason the SWE guys really like lng,lat coordinates
@@ -196,28 +207,28 @@ coordinatesFromList :: [Double] -> EclipticPosition
 coordinatesFromList (sLng : sLat : c : d : e : f : _) = EclipticPosition sLng sLat c d e f
 -- the underlying library goes to great lengths to not return fewer than 6 data,
 -- it instead uses zeroes for unavailable entries.
-coordinatesFromList _                           = EclipticPosition 0 0 0 0 0 0
+coordinatesFromList _ = EclipticPosition 0 0 0 0 0 0
 
 eclipticFromList :: [Double] -> EclipticPosition
 eclipticFromList = coordinatesFromList
 
 eclipticToList :: EclipticPosition -> [Double]
-eclipticToList (EclipticPosition sLng sLat c d e f) =  (sLng : sLat : c : d : e : f : [])
+eclipticToList (EclipticPosition sLng sLat c d e f) = (sLng : sLat : c : d : e : f : [])
 
 equatorialFromList :: [Double] -> EquatorialPosition
-equatorialFromList (a:b:c:d:e:f:_) = EquatorialPosition a b c d e f
-equatorialFromList _               = EquatorialPosition 0 0 0 0 0 0
+equatorialFromList (a : b : c : d : e : f : _) = EquatorialPosition a b c d e f
+equatorialFromList _ = EquatorialPosition 0 0 0 0 0 0
 
 equatorialToList :: EquatorialPosition -> [Double]
-equatorialToList (EquatorialPosition a b c d e f) =  (a:b:c:d:e:f:[])
+equatorialToList (EquatorialPosition a b c d e f) = (a : b : c : d : e : f : [])
 
-obliquityNutationFromList :: [Double] -> ObliquityAndNutation
-obliquityNutationFromList (a:b:c:d:_:_:_) = ObliquityAndNutation a b c d
-obliquityNutationFromList _               = ObliquityAndNutation 0 0 0 0
+obliquityNutationFromList :: [Double] -> ObliquityInformation
+obliquityNutationFromList (a : b : c : d : _ : _ : _) = ObliquityInformation a b c d
+obliquityNutationFromList _ = ObliquityInformation 0 0 0 0
 
 anglesFromList :: [Double] -> Angles
 anglesFromList (a : _mc : _armc : vtx : ea : cak : cam : pa : _ : _) =
-    Angles a _mc _armc vtx ea cak cam pa
+  Angles a _mc _armc vtx ea cak cam pa
 -- the underlying library always returns _something_, defaulting to zero
 -- if the angle calculation doesn't apply.
 anglesFromList _ = Angles 0 0 0 0 0 0 0 0

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -100,12 +100,6 @@ data EclipticPosition = EclipticPosition
   }
   deriving (Show, Eq, Generic)
 
-{-# DEPRECATED Coordinates "This was an ambiguous type, use EclipticPosition for positions of celestial bodies, or GeographicPosition for a point on Earth." #-}
-
--- | Deprecated type alias, used to mean `EclipticPosition` before we introduced other
--- types of positions.
-type Coordinates = EclipticPosition
-
 -- | Represents a point on Earth, with negative values
 -- for latitude meaning South, and negative values for longitude
 -- meaning West. No speed information is included (or needed,)

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -198,9 +198,18 @@ coordinatesFromList (sLng : sLat : c : d : e : f : _) = EclipticPosition sLng sL
 -- it instead uses zeroes for unavailable entries.
 coordinatesFromList _                           = EclipticPosition 0 0 0 0 0 0
 
+eclipticFromList :: [Double] -> EclipticPosition
+eclipticFromList = coordinatesFromList
+
+eclipticToList :: EclipticPosition -> [Double]
+eclipticToList (EclipticPosition sLng sLat c d e f) =  (sLng : sLat : c : d : e : f : [])
+
 equatorialFromList :: [Double] -> EquatorialPosition
 equatorialFromList (a:b:c:d:e:f:_) = EquatorialPosition a b c d e f
 equatorialFromList _               = EquatorialPosition 0 0 0 0 0 0
+
+equatorialToList :: EquatorialPosition -> [Double]
+equatorialToList (EquatorialPosition a b c d e f) =  (a:b:c:d:e:f:[])
 
 obliquityNutationFromList :: [Double] -> ObliquityAndNutation
 obliquityNutationFromList (a:b:c:d:_:_:_) = ObliquityAndNutation a b c d

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE DeriveGeneric  #-}
+
+{-|
+Module: SwissEphemeris.Internal
+Description: helper functions and types, not for public consumption.
+
+The types defined here are exported publicly for convenience, but at least in versions <= 2.x, they're likely to evolve.
+-}
+
+module SwissEphemeris.Internal where
+
+import Foreign.SwissEphemeris
+import Data.Bits
+import           GHC.Generics
+import Foreign.C.Types
+import Foreign (Int32)
+import Data.Char (ord)
+
+-- | All bodies for which a position can be calculated. Covers planets
+-- in the solar system, points between the Earth and the Moon, and
+-- astrologically significant asteroids (currently, only Chiron, but
+-- ephemerides data is available for others.)
+-- More at <https://www.astro.com/swisseph/swisseph.htm#_Toc46391648 2.1 Planetary and lunar ephemerides>
+-- and <https://www.astro.com/swisseph/swephprg.htm#_Toc49847827 3.2 bodies>
+data Planet = Sun
+            | Moon
+            | Mercury
+            | Venus
+            | Mars
+            | Jupiter
+            | Saturn
+            | Uranus
+            | Neptune
+            | Pluto
+            | MeanNode
+            | TrueNode
+            | MeanApog
+            | OscuApog
+            | Earth
+            | Chiron
+            deriving (Show, Eq, Ord, Enum, Generic)
+
+-- | The major house systems. The underlying library supports many more, including the
+-- 36-cusp outlier Gauquelin.
+-- More info at <https://www.astro.com/swisseph/swisseph.htm#_Toc46391705 6.2 Astrological house systems>
+-- and <https://www.astro.com/swisseph/swephprg.htm#_Toc49847888 14. House cusp calculation>
+data HouseSystem = Placidus
+                 | Koch
+                 | Porphyrius
+                 | Regiomontanus
+                 | Campanus
+                 | Equal
+                 | WholeSign
+                 deriving (Show, Eq, Ord, Enum, Generic)
+
+-- | Represents an instant in Julian time.
+-- see:
+-- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847871 8. Date and time conversion functions>
+-- also cf. `julianDay`
+type JulianTime = Double
+
+-- | The cusp of a given "house" or "sector"
+-- see:
+-- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847888 14.1 House cusp calculation>
+-- and <https://www.astro.com/swisseph/swisseph.htm#_Toc46391705 6.2 Astrological house systems>
+type HouseCusp = Double
+
+-- | Position data for a celestial body, includes rotational speeds.
+-- see:
+-- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847837 3.4 Position and speed>
+data Coordinates = Coordinates
+  {
+    lng :: Double
+  , lat :: Double
+  , distance :: Double -- in AU
+  , lngSpeed :: Double -- deg/day
+  , latSpeed :: Double -- deg/day
+  , distSpeed :: Double -- deg/day
+  } deriving (Show, Eq, Generic)
+
+type EclipticCoordinates = Coordinates
+
+data EquatorialPosition = EquatorialPosition
+  {
+    rightAscension :: Double
+  , declination :: Double
+  , eqDistance  :: Double -- same as distance in `Coordinates`, uses AU
+  , ascensionSpeed :: Double -- deg/day
+  , declinationSpeed :: Double -- deg/day
+  , eqDistanceSpeed :: Double -- deg/day
+  } deriving (Show, Eq, Generic)
+
+data ObliquityAndNutation = ObliquityAndNutation
+  {
+    eclipticObliquity :: Double
+  , eclipticMeanObliquity :: Double
+  , nutationLongitude :: Double
+  , nutationObliquity :: Double
+  } 
+
+-- | Default coordinates with all zeros -- when you don't care about/know the velocities,
+-- which would be the case for most inputs (though most outputs /will/ include them.)
+-- Usually you'll set only lat and lng (e.g. @defaultCoordinates{lat = 1.4, lng = 4.1}@)
+-- when using it as an input for another function.
+defaultCoordinates :: Coordinates
+defaultCoordinates = Coordinates 0 0 0 0 0 0
+
+-- | Constructor alias of `defaultCoordinates`, since it's used a lot in that role.
+mkCoordinates :: Coordinates
+mkCoordinates = defaultCoordinates
+
+-- | Relevant angles: ascendant and MC, plus other "exotic" ones:
+-- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847890 14. House cusp calculation>
+data Angles = Angles
+  {
+    ascendant :: Double
+  , mc :: Double
+  , armc :: Double
+  , vertex :: Double
+  , equatorialAscendant :: Double
+  , coAscendantKoch :: Double
+  , coAscendantMunkasey :: Double
+  , polarAscendant :: Double
+  } deriving (Show, Eq, Generic)
+
+-- | Result of calculating the cusps for a given event; will include a list of
+-- cusps (most systems use 12 cusps, Gauquelin uses 36.)
+data CuspsCalculation = CuspsCalculation
+  {
+    houseCusps :: [HouseCusp]
+  , angles :: Angles
+  , systemUsed :: HouseSystem
+  } deriving (Show, Eq, Generic)
+
+
+-- folders for bitwise flags, and some opinionated defaults.
+
+mkCalculationOptions :: [CalcFlag] -> CalcFlag
+mkCalculationOptions = CalcFlag . foldr ((.|.) . unCalcFlag) 0
+
+defaultCalculationOptions :: [CalcFlag]
+defaultCalculationOptions =  [speed, swissEph]
+
+mkRoundingOptions :: [SplitDegFlag] -> SplitDegFlag
+mkRoundingOptions = SplitDegFlag . foldr ((.|.) . unSplitDegFlag) 0
+
+defaultRoundingOptions :: [SplitDegFlag]
+defaultRoundingOptions = 
+    [ splitKeepDeg  -- don't round up to the next degree
+    , splitKeepSign -- don't round up to the next sign
+    , splitZodiacal -- reference zodiacal signs
+    , splitRoundSec -- don't need second fractions.
+    ]
+
+-- helpers
+
+-- Helpers
+
+-- in the C lib, house systems are expected as ASCII
+-- codes for specific characters (!)
+-- documentation at: https://www.astro.com/swisseph/swephprg.htm#_Toc19111265
+toHouseSystemFlag :: HouseSystem -> Int
+toHouseSystemFlag Placidus      = ord 'P'
+toHouseSystemFlag Koch          = ord 'K'
+toHouseSystemFlag Porphyrius    = ord 'O'
+toHouseSystemFlag Regiomontanus = ord 'R'
+toHouseSystemFlag Campanus      = ord 'C'
+toHouseSystemFlag Equal         = ord 'A'
+toHouseSystemFlag WholeSign     = ord 'W'
+
+coordinatesFromList :: [Double] -> Coordinates
+-- N.B. note that for some reason the SWE guys really like lng,lat coordinates
+-- though only for this one function: https://www.astro.com/swisseph/swephprg.htm#_Toc19111235
+coordinatesFromList (sLng : sLat : c : d : e : f : _) = Coordinates sLng sLat c d e f
+-- the underlying library goes to great lengths to not return fewer than 6 data,
+-- it instead uses zeroes for unavailable entries.
+coordinatesFromList _                           = Coordinates 0 0 0 0 0 0
+
+equatorialFromList :: [Double] -> EquatorialPosition
+equatorialFromList (a:b:c:d:e:f:_) = EquatorialPosition a b c d e f
+equatorialFromList _               = EquatorialPosition 0 0 0 0 0 0
+
+obliquityNutationFromList :: [Double] -> ObliquityAndNutation
+obliquityNutationFromList (a:b:c:d:_:_:_) = ObliquityAndNutation a b c d
+obliquityNutationFromList _               = ObliquityAndNutation 0 0 0 0
+
+anglesFromList :: [Double] -> Angles
+anglesFromList (a : _mc : _armc : vtx : ea : cak : cam : pa : _ : _) =
+    Angles a _mc _armc vtx ea cak cam pa
+-- the underlying library always returns _something_, defaulting to zero
+-- if the angle calculation doesn't apply.
+anglesFromList _ = Angles 0 0 0 0 0 0 0 0
+
+planetNumber :: Planet -> PlanetNumber
+planetNumber p = PlanetNumber $ CInt y
+  where
+    y = fromIntegral $ fromEnum p :: Int32

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -60,13 +60,16 @@ data HouseSystem = Placidus
 type JulianTime = Double
 newtype SiderealTime = SiderealTime {unSidereal :: Double}
     deriving (Show, Eq)
-sidToArmc :: SiderealTime -> ARMC
-sidToArmc s = ARMC $ (unSidereal s) * 15
+
+-- | Convert tropical sidereal time to an ARMC relative to a given longitude
+-- this is not explained in the SWE docs, I pulled it from:
+--   armc = swe_degnorm(swe_sidtime0(tjd_ut, eps + nutlo[1], nutlo[0]) * 15 + geolon);
+-- (line 144 of swehouse.c, part of swe_houses)
+sidToArmc :: SiderealTime -> Double -> ARMC
+sidToArmc s l = ARMC $ (unSidereal s) * 15 + l
 
 newtype ARMC = ARMC {unArmc :: Double}
     deriving (Show, Eq)
-armcToSid :: ARMC -> SiderealTime
-armcToSid a = SiderealTime $ (unArmc a) / 15
 
 -- | The cusp of a given "house" or "sector"
 -- see:
@@ -105,7 +108,7 @@ data ObliquityAndNutation = ObliquityAndNutation
   , eclipticMeanObliquity :: Double
   , nutationLongitude :: Double
   , nutationObliquity :: Double
-  } 
+  } deriving (Show, Eq, Generic)
 
 -- | Default coordinates with all zeros -- when you don't care about/know the velocities,
 -- which would be the case for most inputs (though most outputs /will/ include them.)

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -166,6 +166,16 @@ data CuspsCalculation = CuspsCalculation
   }
   deriving (Show, Eq, Generic)
 
+-- | A longitude expressed in its constituent parts.
+data LongitudeComponents = LongitudeComponents
+  { longitudeZodiacSign :: Maybe ZodiacSignName,
+    longitudeDegrees :: Integer,
+    longitudeMinutes :: Integer,
+    longitudeSeconds :: Integer,
+    longitudeSecondsFraction :: Double
+  }
+  deriving (Show, Eq, Generic)
+
 -- folders for bitwise flags, and some opinionated defaults.
 
 mkCalculationOptions :: [CalcFlag] -> CalcFlag
@@ -174,18 +184,14 @@ mkCalculationOptions = CalcFlag . foldr ((.|.) . unCalcFlag) 0
 defaultCalculationOptions :: [CalcFlag]
 defaultCalculationOptions = [speed, swissEph]
 
-mkRoundingOptions :: [SplitDegFlag] -> SplitDegFlag
-mkRoundingOptions = SplitDegFlag . foldr ((.|.) . unSplitDegFlag) 0
+mkSplitDegOptions :: [SplitDegFlag] -> SplitDegFlag
+mkSplitDegOptions = SplitDegFlag . foldr ((.|.) . unSplitDegFlag) 0
 
-defaultRoundingOptions :: [SplitDegFlag]
-defaultRoundingOptions =
+defaultSplitDegOptions :: [SplitDegFlag]
+defaultSplitDegOptions =
   [ splitKeepDeg, -- don't round up to the next degree
-    splitKeepSign, -- don't round up to the next sign
-    splitZodiacal, -- reference zodiacal signs
-    splitRoundSec -- don't need second fractions.
+    splitKeepSign -- don't round up to the next sign
   ]
-
--- helpers
 
 -- Helpers
 

--- a/swiss-ephemeris.cabal
+++ b/swiss-ephemeris.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3000345ad0f1743d5d07d502ab8a82e9041a9ce0c3638099da145a5987d1f3a0
+-- hash: 85a5817c2900835df245adf32d7bd8efc4c19c8a6a7811a4a962567857a1ce96
 
 name:           swiss-ephemeris
 version:        1.0.0.0
@@ -30,6 +30,7 @@ library
   exposed-modules:
       Foreign.SwissEphemeris
       SwissEphemeris
+      SwissEphemeris.Internal
   other-modules:
       Paths_swiss_ephemeris
   hs-source-dirs:

--- a/swiss-ephemeris.cabal
+++ b/swiss-ephemeris.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 85a5817c2900835df245adf32d7bd8efc4c19c8a6a7811a4a962567857a1ce96
+-- hash: 25f7b59663125c750ee70fd238ed152f8c7496541d173c1e07bcb3944b332ee1
 
 name:           swiss-ephemeris
-version:        1.0.0.0
+version:        1.1.0.0
 synopsis:       Haskell bindings for the Swiss Ephemeris C library
 description:    Please see the README on GitHub at <https://github.com/lfborjas/swiss-ephemeris#readme>
 category:       Data, Astrology

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -114,7 +114,42 @@ spec = do
           assert $ (systemUsed calcs) == houseSystem
           assert $ (length $ houseCusps calcs) == 12
 
+    describe "calculateHousePositionSimple" $ do
+      it "calculates accurate house positions for some known planets" $ do
+        let time = julianDay 1989 1 6 0.0
+            place = mkCoordinates{lat = 14.06, lng = -87.13}
+            housePos = calculateHousePositionSimple Placidus time place
+            houseN = fmap houseNumber
 
+        sunH     <- housePos $ mkCoordinates{lng=285.6465775, lat=(-0.0000826)}
+        moonH    <- housePos $ mkCoordinates{lng=262.4723493, lat=(-4.9055744)}
+        mercuryH <- housePos $ mkCoordinates{lng=304.3135759, lat=(-1.3441786)}
+        venusH   <- housePos $ mkCoordinates{lng=264.0478768, lat=(0.6114330)}
+        marsH    <- housePos $ mkCoordinates{lng=22.7844912,  lat=(0.6472527)}
+        jupiterH <- housePos $ mkCoordinates{lng=56.4415899,  lat=(-0.8785552)}
+        saturnH  <- housePos $ mkCoordinates{lng=276.1819323, lat=(0.7124667)}
+        uranusH  <- housePos $ mkCoordinates{lng=272.0516769, lat=(-0.2200407)}
+        neptuneH <- housePos $ mkCoordinates{lng=280.1110192, lat=(0.9024311)}
+        plutoH   <- housePos $ mkCoordinates{lng=224.6817137, lat=(15.6296117)}
+        meanNH   <- housePos $ mkCoordinates{lng=337.5235158, lat=(0.0)}
+        chironH  <- housePos $ mkCoordinates{lng=93.5373174,  lat=(-6.8493261)}
+
+        houseN sunH `shouldBe` Right 6
+        houseN moonH `shouldBe` Right 5
+        houseN mercuryH `shouldBe` Right 7
+        houseN venusH `shouldBe` Right 6
+        houseN marsH `shouldBe` Right 10
+        houseN jupiterH `shouldBe` Right 11
+        houseN saturnH `shouldBe` Right 6
+        houseN uranusH `shouldBe` Right 6
+        houseN neptuneH `shouldBe` Right 6
+        houseN plutoH   `shouldBe` Right 4
+        houseN meanNH   `shouldBe` Right 8
+        houseN chironH  `shouldBe` Right 12
+
+      -- TODO: write property test, though this function isn't as useful as I thought:
+      -- https://groups.io/g/swisseph/message/4052
+      
   around_ ( withEphemerides ephePath ) $ do
     describe "calculateCoordinates with bundled ephemeris" $ do
       prop "calculates coordinates for any of the planets in a wide range of time." $
@@ -125,6 +160,7 @@ spec = do
         forAll genBadCoordinatesQuery $ \(time, planet) -> monadicIO $ do
           coords <- run $ calculateCoordinates time planet
           assert $ isLeft coords
+
 
 {- For reference, here's an official test output from swetest.c as retrieved from the swetest page:
 https://www.astro.com/cgi/swetest.cgi?b=6.1.1989&n=1&s=1&p=p&e=-eswe&f=PlbRS&arg=

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -114,6 +114,12 @@ spec = do
           assert $ (systemUsed calcs) == houseSystem
           assert $ (length $ houseCusps calcs) == 12
 
+    describe "coordinate transformation" $ do
+      it "converts between ecliptic and equatorial" $ do
+        let e = eclipticToEquatorial (ObliquityAndNutation (23.2) 0 0 0) $ EclipticPosition 285.6465775 (-0.0000826) 1 0 0 0
+            equatorial = EquatorialPosition {rightAscension = 286.9471857576873, declination = -22.29312747773143, eqDistance = 1.0, ascensionSpeed = 0.0, declinationSpeed = 0.0, eqDistanceSpeed = 0.0}
+        e `shouldBe` equatorial
+
     describe "calculateHousePositionSimple" $ do
       it "calculates accurate house positions for some known planets" $ do
         let time = julianDay 1989 1 6 0.0

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -149,7 +149,11 @@ spec = do
 
       -- TODO: write property test, though this function isn't as useful as I thought:
       -- https://groups.io/g/swisseph/message/4052
-      
+    
+    describe "calculateEquatorialPosition" $ do
+      it "calculates the declination and other points of interest" $ do 
+        pendingWith "sleepy"
+
   around_ ( withEphemerides ephePath ) $ do
     describe "calculateCoordinates with bundled ephemeris" $ do
       prop "calculates coordinates for any of the planets in a wide range of time." $


### PR DESCRIPTION
**BREAKING CHANGE:** the `Coordinates` type has been retired, in favor of the more specific
`GeographicPosition` and `EclipticPosition`. `calculateCoordinates` is now `calculateEclipticPosition`,
and the `calculateCusps*` family now takes a `GeographicPosition` as part of its inputs.

* Introduces an `Internal` module with types and helpers that this library introduces,
  which are not native to the underlying C library. Import at your own risk! (the "curated"/
  "stable" ones are re-exported by the main module.)
  - Deprecates the `Coordinates` type, in favor of `EclipticPosition`.
* Introduces functions to `calculateEquatorialPosition` and `calculteObliquity` at a given time,
  as well as types that better convey the different types of positions (`EquatorialPosition`, `ObliquityInformation`).
* Some astrology helpers: convert between equatorial and ecliptic (and vice-versa,)
  obtain the Delta Time effective at a given moment, obtain the house position of a given body.
  (**Note:** the `calculateHousePosition` function is more useful for working near the polar circles or for bodies
  off of the ecliptic -- the ARMC and obliquity need to be calculated or provided, it's simpler
  if you already have the cusps: just check which cusps a given longitude falls between -- no need for
  this function!)