### PR TITLE
Bindings for crossings, eclipses, and planetary phenomena

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,23 @@
 
 ## v1.4.0.0
 
+**BREAKING CHANGE:** Major refactoring of time values: `JulianDay` is no longer an alias for `Double`,
+and is now a type that carries a witness of its provenance -- which enables us to work with functions that
+transact in both Terrestrial (Ephemeris) Time, and Universal Time, without mixing them up.
+
+* Upgrades to version `2.10.02` of the C library.
 * Adds the `Precalculated` namespace with functions to read and write pre-calculated
-  ephemeris from a file on disk.
+  ephemeris from a file on disk. Useful when examining an interval of time for ecliptic phenomena.
+* Introduces the `SwissEphemeris.Time` module, with various conversions between time standards
+  and some Haskell time values.
+* Introduces functions that find moments of exactitude for longitude crossings (heliocentric and geocentric,) 
+  and moments of exactitude for lunar phases. The geocentric interpolation, as well as lunar phases,
+  use the Brent-Dekker algorithm for root finding, the heliocentric functions are able to do faster
+  parabolic approximation. I need to study the C sources a bit more to see if something similar is possible
+  for interpolation in general (see the `events` files in the C sources for ideas.)
+* Adds functions for calculating planetary phenomena as visible from earth, as well as solar and lunar eclipses.
 * [dev] adds a `Dockerfile` and `NOTES.md` to aid in diagnosing memory leaks.
+* [dev] adds some basic Nix derivations for producing documentations and a release tarball.
 
 ## v1.3.0.2
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,13 @@
+## Reproducing tests failures
+
+When a quickcheck prop fails, one can re-run with the same seed:
+
+```sh
+stack test --test-arguments="--seed=1152638838"
+```
+
+(odd syntax bemoned at: https://github.com/commercialhaskell/stack/issues/2210)
+
 ## Detecting memory leaks/corruption
 
 First of all, macOS is a terrible environment for this: between having enough

--- a/csrc/interpolate.c
+++ b/csrc/interpolate.c
@@ -322,6 +322,8 @@ static int brent_dekker(callback_fn f, double start, double end, double epsilon,
     *root = s;
   } else if (fabs(fb) <= epsilon) {
     *root = b;
+  } else if (fabs(b-a) < epsilon) {
+    *root = b;
   } else {
     sprintf(serr, "swe_interpolate: no root found within %d iterations, and epsilon %lf", i, epsilon);
     return ERR;

--- a/csrc/interpolate.c
+++ b/csrc/interpolate.c
@@ -133,11 +133,14 @@ int swe_interpolate_ut(int ipl, double x2cross, double jd0_ut, double jd_ut_end,
   return rval;
 }
 
-/* Given two time values that bracket a planet's crossing, use Brent's method to find the exact moment of crossing
+/* Given two time values that bracket a planet's crossing, use the Brent-Dekker algorithm to find the exact moment of crossing
    from: https://en.wikipedia.org/wiki/Brent%27s_method.
    Defaults to 100 iterations, with a tolerance of one milliarcsecond. It is recommended that you provide values
-   that are somewhat known to contain a crossing; if a crossing isn't contained, it'll fail with a 'not bracketed''
+   that are known to contain a crossing; if a crossing isn't contained, it'll fail fast with a 'not bracketed'
    error; and if the interval is too long, it will run out of iterations.
+
+   Note that in rare cases, a planet may cross a given longitude more than once in any given interval of time.
+   We only find the first such crossing here.
 */
 int swe_interpolate(int ipl, double x2cross, double jd0, double jd_end, int iflag, double *jdx, char *serr)
 {

--- a/csrc/interpolate.c
+++ b/csrc/interpolate.c
@@ -152,6 +152,17 @@ int swe_interpolate(int ipl, double x2cross, double jd0, double jd_end, int ifla
   return brent_dekker(&crosses, jd0, jd_end, CROSS_PRECISION, 100, jdx, &cross, serr);
 }
 
+int swe_interpolate_moon_phase_ut(double phase, double jd0_ut, double jd_end_ut, int iflag, double *jdx, char *serr)
+{
+  double jd0 = jd0_ut + swe_deltat(jd0_ut);
+  double jd_end = jd_end_ut + swe_deltat(jd_end_ut);
+  double tx;
+  int rval = swe_interpolate_moon_phase(phase, jd0, jd_end, iflag, &tx, serr);
+  if (rval >= 0)
+    *jdx = tx - swe_deltat(tx);
+  return rval;
+ 
+}
 /* Given a phase (angle between moon and sun positions) and a timeframe during which
    the phase happens, try to find the moment of exactitude. */
 int swe_interpolate_moon_phase(double phase, double jd0, double jd_end, int iflag, double *jdx, char *serr)

--- a/csrc/interpolate.c
+++ b/csrc/interpolate.c
@@ -6,7 +6,7 @@
 // The start moment jd0_ut must be at least 30 minutes before the direction change.
 int swe_next_direction_change_ut(double jd0, int ipl, int iflag, double *jdx, int *idir, char *serr)
 {
-  double jd_end = jd0 + 700; // default to looking within two years from the start date
+  double jd_end = jd0 + 1000; // default to looking within three years from the start date
   return swe_next_direction_change_ut_between(
     jd0,
     jd_end,
@@ -31,7 +31,7 @@ int swe_next_direction_change_ut_between(double jd0_ut, double jd_ut_end, int ip
 
 int swe_next_direction_change(double jd0, int ipl, int iflag, double *jdx, int *idir, char *serr)
 {
-  double jd_end = jd0 + 700; // default to looking within two years from now
+  double jd_end = jd0 + 1000; // default to looking within three years from now
   return swe_next_direction_change_between(
     jd0,
     jd_end,

--- a/csrc/interpolate.c
+++ b/csrc/interpolate.c
@@ -1,0 +1,120 @@
+#include "swephexp.h"
+#include "interpolate.h"
+
+// jdx   must be pointer to double, returns moment of direction change
+// idir  must be pointer to integer, returns -1 if objects gets retrograde, 1 if direct
+// The start moment jd0_ut must be at least 30 minutes before the direction change.
+int swe_next_direction_change_ut(double jd0, int ipl, int iflag, double *jdx, int *idir, char *serr)
+{
+  double jd_end = jd0 + 700; // default to looking within two years from the start date
+  return swe_next_direction_change_ut_between(
+    jd0,
+    jd_end,
+    ipl,
+    iflag,
+    jdx,
+    idir,
+    serr
+  );
+}
+
+int swe_next_direction_change_ut_between(double jd0_ut, double jd_ut_end, int ipl, int iflag, double *jdx, int *idir, char *serr)
+{
+  double jd0 = jd0_ut + swe_deltat(jd0_ut);
+  double jd_end = jd_ut_end + swe_deltat(jd_ut_end);
+  double tx;
+  int rval = swe_next_direction_change_between(jd0, jd_end, ipl, iflag, &tx, idir, serr);
+  if (rval >= 0)
+    *jdx = tx - swe_deltat(tx);
+  return rval;
+}
+
+int swe_next_direction_change(double jd0, int ipl, int iflag, double *jdx, int *idir, char *serr)
+{
+  double jd_end = jd0 + 700; // default to looking within two years from now
+  return swe_next_direction_change_between(
+    jd0,
+    jd_end,
+    ipl,
+    iflag,
+    jdx,
+    idir,
+    serr
+  );
+}
+
+int swe_next_direction_change_between(double jd0, double jd_end, int ipl, int iflag, double *jdx, int *idir, char *serr)
+{
+  double jd_step = 1;
+  double xx[6], d1, d2, y0, y1, y2, a, b, jd, tx;
+  int rval, is;
+  if (jd_step <= 0) jd_step = 1.0;
+  // NOTE(luis) adding a couple of days to the end of the search since 3 positions
+  // are needed for interpolation, at least.
+  double orig_end = jd_end;
+  if (fabs(jd_end - jd0) < 3){
+    jd_end += 3;
+  }
+  rval = swe_calc(jd0, ipl, iflag, xx, serr);
+  if (rval < 0) return rval; 
+  y0 = xx[0];
+  for (is = 0, jd = jd0 + jd_step; jd <= jd_end; is++, jd += jd_step) {
+    rval = swe_calc(jd, ipl, iflag, xx, serr);
+    if (rval < 0) return rval; 
+    if (is == 0) {	// we need at least 3 steps
+      y1 = xx[0];
+      continue;
+    }
+    y2 = xx[0];
+    // get parabola y = ax^2  + bx + c  and derivative y' = 2ax + b
+    d1 = swe_difdeg2n(y1, y0);
+    d2 = swe_difdeg2n(y2, y1);
+    y0 = y1;	// for next step
+    y1 = y2;
+    b = (d1 + d2) / 2;
+    a = (d2 - d1) / 2;
+    if (a == 0) continue;	// curve is flat
+    tx = - b / a / 2.0;		// time when derivative is zer0
+    if (tx < -1 || tx > 1) continue;
+    *jdx = jd - jd_step + tx * jd_step;
+    if (*jdx - jd0 < 30.0 / 1440) continue;	// ignore if within 30 minutes of start moment
+    while (jd_step > 2 / 1440.0) {
+      jd_step = jd_step / 2;
+      double t1 = *jdx;
+      double t0 = t1 - jd_step;
+      double t2 = t1 + jd_step;
+      rval = swe_calc(t0 , ipl, iflag, xx, serr);
+      if (rval < 0) return rval; 
+      y0 = xx[0];
+      rval = swe_calc(t1 , ipl, iflag, xx, serr);
+      if (rval < 0) return rval; 
+      y1 = xx[0];
+      rval = swe_calc(t2 , ipl, iflag, xx, serr);
+      if (rval < 0) return rval; 
+      y2 = xx[0];
+      d1 = swe_difdeg2n(y1, y0);
+      d2 = swe_difdeg2n(y2, y1);
+      b = (d1 + d2) / 2;
+      a = (d2 - d1) / 2;
+      if (a == 0) continue;	// curve is flat
+      tx = - b / a / 2.0;		// time when derivative is zer0
+      if (tx < -1 || tx > 1) continue;
+      *jdx = t1 + tx * jd_step;
+      double tdiff = fabs(*jdx - t1);
+      if (tdiff < 1 / 86400.0) break;
+    }
+    if (a > 0)
+      *idir = 1;
+    else
+      *idir = -1;
+    if (*jdx > orig_end){
+      sprintf(serr, "swe_next_direction_change: no change within %lf days",  (orig_end - jd0));
+      return ERR;
+    }
+    return rval;
+  }
+  // come here only if no change found in loop
+  if (serr != NULL)
+    sprintf(serr, "swe_next_direction_change: no change within %lf days",  (orig_end - jd0));
+  return ERR;
+}

--- a/csrc/interpolate.c
+++ b/csrc/interpolate.c
@@ -182,6 +182,7 @@ int swe_interpolate(int ipl, double x2cross, double jd0, double jd_end, int ifla
   
   c = a;
   fc = fa;
+  s = b;
   fs = fb;
   mflag = TRUE;
   

--- a/csrc/interpolate.h
+++ b/csrc/interpolate.h
@@ -11,3 +11,5 @@ int swe_next_direction_change(double jd0, int ipl, int iflag, double *jdx, int *
 int swe_next_direction_change_between(double jd0, double jd_end, int ipl, int iflag, double *jdx, int *idir, char *serr);
 int swe_next_direction_change_ut(double jd0, int ipl, int iflag, double *jdx, int *idir, char *serr);
 int swe_next_direction_change_ut_between(double jd0, double jd_end, int ipl, int iflag, double *jdx, int *idir, char *serr);
+int swe_interpolate(int ipl, double x2cross, double jd0, double jd_end, int iflag, double *jdx, char *serr);
+int swe_interpolate_ut(int ipl, double x2cross, double jd0, double jd_end, int iflag, double *jdx, char *serr);

--- a/csrc/interpolate.h
+++ b/csrc/interpolate.h
@@ -7,9 +7,24 @@ Stated to be in the public domain in the aforementioned listing, i.e.
 */
 
 #include "swephexp.h"
+
+/* callbacks for interpolation; always return an OK/ERR int, take a double and return
+   a pointer to a double result; optional additional data can be passed through a void
+   pointer; an error string can be provided. */
+typedef int (*callback_fn)(double, double*, void*, char*);
+
+typedef struct crossing_target{
+  double x2cross; /* longitude we're seeking to cross */
+  int iflag; /* ephemeris flag */
+  int crossing_planet; /* planet number */ 
+} crossing_data;
+
 int swe_next_direction_change(double jd0, int ipl, int iflag, double *jdx, int *idir, char *serr);
 int swe_next_direction_change_between(double jd0, double jd_end, int ipl, int iflag, double *jdx, int *idir, char *serr);
 int swe_next_direction_change_ut(double jd0, int ipl, int iflag, double *jdx, int *idir, char *serr);
 int swe_next_direction_change_ut_between(double jd0, double jd_end, int ipl, int iflag, double *jdx, int *idir, char *serr);
 int swe_interpolate(int ipl, double x2cross, double jd0, double jd_end, int iflag, double *jdx, char *serr);
 int swe_interpolate_ut(int ipl, double x2cross, double jd0, double jd_end, int iflag, double *jdx, char *serr);
+//helpers
+static int crosses(double t, double *xt, void *data, char *serr);
+static int brent_dekker(callback_fn f, double start, double end, double epsilon, int max_iter, double *root, void *f_data, char *serr);

--- a/csrc/interpolate.h
+++ b/csrc/interpolate.h
@@ -1,0 +1,13 @@
+/*
+Shared by Alois in the swiss ephemeris forum:
+https://groups.io/g/swisseph/message/7781
+
+Stated to be in the public domain in the aforementioned listing, i.e.
+// This code is in the public domain, no warranty!
+*/
+
+#include "swephexp.h"
+int swe_next_direction_change(double jd0, int ipl, int iflag, double *jdx, int *idir, char *serr);
+int swe_next_direction_change_between(double jd0, double jd_end, int ipl, int iflag, double *jdx, int *idir, char *serr);
+int swe_next_direction_change_ut(double jd0, int ipl, int iflag, double *jdx, int *idir, char *serr);
+int swe_next_direction_change_ut_between(double jd0, double jd_end, int ipl, int iflag, double *jdx, int *idir, char *serr);

--- a/csrc/interpolate.h
+++ b/csrc/interpolate.h
@@ -19,12 +19,19 @@ typedef struct crossing_target{
   int crossing_planet; /* planet number */ 
 } crossing_data;
 
+typedef struct moon_phase_target{
+  double phase_angle; /* angle between moon and sun positions, in [0, 360) */
+  int iflag;
+} moon_phase_data;
+
 int swe_next_direction_change(double jd0, int ipl, int iflag, double *jdx, int *idir, char *serr);
 int swe_next_direction_change_between(double jd0, double jd_end, int ipl, int iflag, double *jdx, int *idir, char *serr);
 int swe_next_direction_change_ut(double jd0, int ipl, int iflag, double *jdx, int *idir, char *serr);
 int swe_next_direction_change_ut_between(double jd0, double jd_end, int ipl, int iflag, double *jdx, int *idir, char *serr);
 int swe_interpolate(int ipl, double x2cross, double jd0, double jd_end, int iflag, double *jdx, char *serr);
 int swe_interpolate_ut(int ipl, double x2cross, double jd0, double jd_end, int iflag, double *jdx, char *serr);
+int swe_interpolate_moon_phase(double phase, double jd0, double jd_end, int iflag, double *jdx, char *serr);
 //helpers
 static int crosses(double t, double *xt, void *data, char *serr);
+static int moon_phase_matches(double t, double *phase, void *vdata, char *serr);
 static int brent_dekker(callback_fn f, double start, double end, double epsilon, int max_iter, double *root, void *f_data, char *serr);

--- a/csrc/interpolate.h
+++ b/csrc/interpolate.h
@@ -31,6 +31,7 @@ int swe_next_direction_change_ut_between(double jd0, double jd_end, int ipl, int
 int swe_interpolate(int ipl, double x2cross, double jd0, double jd_end, int iflag, double *jdx, char *serr);
 int swe_interpolate_ut(int ipl, double x2cross, double jd0, double jd_end, int iflag, double *jdx, char *serr);
 int swe_interpolate_moon_phase(double phase, double jd0, double jd_end, int iflag, double *jdx, char *serr);
+int swe_interpolate_moon_phase_ut(double phase, double jd0_ut, double jd_end_ut, int iflag, double *jdx, char *serr);
 //helpers
 static int crosses(double t, double *xt, void *data, char *serr);
 static int moon_phase_matches(double t, double *phase, void *vdata, char *serr);

--- a/csrc/swecl.c
+++ b/csrc/swecl.c
@@ -4542,14 +4542,15 @@ nazalt++;
       for (; dt > 0.0001; dt /= 3) {
         for (i = 0, tt = tcu - dt; i < 3; tt += dt, i++) {
           te = tt + swe_deltat_ex(tt, epheflag, serr);
-          if (!do_fixstar)
+          if (!do_fixstar) {
             if (swe_calc(te, ipl, iflag, xc, serr) == ERR)
               return ERR;
-	    if (rsmi & SE_BIT_GEOCTR_NO_ECL_LAT)
-	      xc[1] = 0;
-ncalc++;
+	  }
+	  if (rsmi & SE_BIT_GEOCTR_NO_ECL_LAT)
+	    xc[1] = 0;
+	  ncalc++;
           swe_azalt(tt, tohor_flag, geopos, atpress, attemp, xc, ah);
-nazalt++;
+	  nazalt++;
 	  ah[1] -= horhgt;
           dc[i] = ah[1];
         }

--- a/csrc/swedate.c
+++ b/csrc/swedate.c
@@ -585,3 +585,4 @@ void CALL_CONV swe_jdut1_to_utc(double tjd_ut, int32 gregflag, int32 *iyear, int
   double tjd_et = tjd_ut + swe_deltat_ex(tjd_ut, -1, NULL);
   swe_jdet_to_utc(tjd_et, gregflag, iyear, imonth, iday, ihour, imin, dsec);
 }
+

--- a/csrc/swedll.h
+++ b/csrc/swedll.h
@@ -115,6 +115,23 @@ DllImport int32 CALL_CONV_IMP swe_calc_ut(
         double *xx,
         char *serr);
 
+DllImport double CALL_CONV_IMP swe_solcross(
+	double x2cross, double jd_et, int32 flag, char *serr);
+DllImport double CALL_CONV_IMP swe_solcross_ut(
+	double x2cross, double jd_ut, int32 flag, char *serr);
+DllImport double CALL_CONV_IMP swe_mooncross(
+	double x2cross, double jd_et, int32 flag, char *serr);
+DllImport double CALL_CONV_IMP swe_mooncross_ut(
+	double x2cross, double jd_ut, int32 flag, char *serr);
+DllImport double CALL_CONV_IMP swe_mooncross_node(
+	double jd_et, int32 flag, double *xlon, double *xlat, char *serr);
+DllImport double CALL_CONV_IMP swe_mooncross_node_ut(
+	double jd_ut, int32 flag, double *xlon, double *xlat, char *serr);
+DllImport int32 CALL_CONV_IMP swe_helio_cross(
+	int ipl, double x2cross, double jd_et, int32 iflag, int32 dir, double *jd_cross, char *serr);
+DllImport int32 CALL_CONV_IMP swe_helio_cross_ut(
+	int ipl, double x2cross, double jd_ut, int32 iflag, int32 dir, double *jd_cross, char *serr);
+
 DllImport int32 CALL_CONV_IMP swe_fixstar(
         char *star, double tjd, int32 iflag, 
         double *xx,

--- a/csrc/swehel.c
+++ b/csrc/swehel.c
@@ -476,10 +476,10 @@ if (eventflag & SE_CALC_RISE) {
   /* semidiurnal arc of sun */
   sda = acos(-tan(dgeo[1] * DEGTORAD) * tan(xx[1] * DEGTORAD)) * RADTODEG;
   /* rough rising and setting times */
-if (eventflag & SE_CALC_RISE)
-  tjdrise = tjdnoon - sda / 360.0;
-else
-  tjdrise = tjdnoon + sda / 360.0;
+  if (eventflag & SE_CALC_RISE)
+    tjdrise = tjdnoon - sda / 360.0;
+  else
+    tjdrise = tjdnoon + sda / 360.0;
   /*ph->tset = tjd_start + sda / 360.0;*/
   /* now calculate more accurate rising and setting times.
    * use vertical speed in order to determine crossing of the horizon  
@@ -1816,7 +1816,7 @@ static void strcpy_VBsafe(char *sout, char *sin)
   sp = sin; 
   sp2 = sout;
   /* note, star name may begin with comma, such as ",zePsc" */
-  while((isalnum(*sp) || *sp == ' ' || *sp == '-' || *sp == ',') && iw < 30) {
+  while((isalnum((int) *sp) || *sp == ' ' || *sp == '-' || *sp == ',') && iw < 30) {
     *sp2 = *sp;
     sp++; sp2++; iw++;
   }

--- a/csrc/swehouse.c
+++ b/csrc/swehouse.c
@@ -656,6 +656,7 @@ int CALL_CONV swe_houses_armc_ex2(
   }
   retc = CalcH(armc, geolat, eps, (char)hsys, &h);
   cusp[0] = 0;
+  if (h.do_hspeed) cusp_speed[0] = 0;
   // on failure, we only have 12 Porphyry cusps
   if (retc < 0) {
     ito = 12;
@@ -834,6 +835,7 @@ char *CALL_CONV swe_house_name(int hsys)
   case 'H': return "horizon/azimut";
   case 'I': return "Sunshine";
   case 'i': return "Sunshine/alt.";
+  case 'J': return "Savard-A";
   case 'K': return "Koch";
   case 'L': return "Pullen SD";
   case 'M': return "Morinus";
@@ -854,8 +856,8 @@ char *CALL_CONV swe_house_name(int hsys)
 
 // How to deal with Sunshine houses if the southern crossing point of Equator
 // and Ecliptic is under the horizon:
-// We follow the proposal by Dieter Koch, who wants to keep it in alalogy with
-// Regiomontanus, where we keep the MC above the horozon, by switching it to the noth.
+// We follow the proposal by Dieter Koch, who wants to keep it in analogy with
+// Regiomontanus, where we keep the MC above the horizon, by switching it to the north.
 // This results in an clockwise sequence of house cusps in the chart.
 //
 // One can argue that the MC should be kept south, even when it is under the horizon.
@@ -898,6 +900,7 @@ static int CalcH(
  *                   H  horizon / azimut
  *                   I  Sunshine solution Treindl
  *                   i  Sunshine solution Makransky
+ *                   J  Savard-A
  *                   K  Koch
  *                   L  Pullen SD "sinusoidal delta", ex Neo-Porphyry
  *                   M  Morinus
@@ -918,15 +921,15 @@ static int CalcH(
  * *********************************************************
  *  Koch and Placidus don't work in the polar circle.
  *  We swap MC/IC so that MC is always before AC in the zodiac
- *  We than divide the quadrants into 3 equal parts.
+ *  We then divide the quadrants into 3 equal parts, ie apply Porphyry.
  * *********************************************************
  *  All angles are expressed in degrees.
  *  Special trigonometric functions sind, cosd etc. are
  *  implemented for arguments in degrees.
  ***********************************************************/
 {
-  double tane, tanfi, cosfi, tant, sina, cosa, th2;
-  double a, c, f, fh1, fh2, xh1, xh2, rectasc, ad3, acmc, vemc;
+  double tane, tanfi, cosfi, sinfi, tant, sina, cosa, th2;
+  double a, c, f, fh1, fh2, xh1, xh2, xs1, xs2, rectasc, ad3, acmc, vemc;
   int 	i, ih, ih2, retc = OK;
   double sine, cose;
   double x[3], krHorizonLon; /* BK 14.02.2006 */
@@ -1016,24 +1019,18 @@ static int CalcH(
       }
     }
     break;
-  case 'C': /* Campanus houses and Horizon or Azimut system */
-  case 'H':
-    if (hsy == 'H') {
-      if (fi > 0)
-        fi = 90 - fi;
-      else
-        fi = -90 - fi;
-      /* equator */
-      if (fabs(fabs(fi) - 90) < VERY_SMALL) {
-        if (fi < 0)
-          fi = -90 + VERY_SMALL;
-        else
-	  fi = 90 - VERY_SMALL;
-      } 
-      th = swe_degnorm(th + 180);
-    }
+  case 'C': // Campanus houses:
+    // Prime vertical is divided into 3 parts of 30° each, great circles from
+    // north point to south point go through these points and intersect ecliptic.
+    // pole height = shortest distance of plane from North pole,
+    // measured along declination circle.
+    // NP = North Pole, N = north point, P11 = house 11 point in prime vertical
+    // triangle NP - N - P11 , angle 30 at N, side fi between NP and N
+    // sin fh1 = sin fi * sin 30°,
     fh1 = asind(sind (fi) / 2);
-    fh2 = asind(sqrt (3.0) / 2 * sind(fi));
+    // triangle NP - N - P12 , angle 60 at N, side fi between NP and N
+    // sin fh2 = sin fi * sin 60°,
+    fh2 = asind(sqrt (3.0) / 2 * sind(fi)); 
     cosfi = cosd(fi);
     if (fabs(cosfi) == 0) {	/* '==' should be save! */ 
       if (fi > 0)
@@ -1041,20 +1038,23 @@ static int CalcH(
       else
 	xh1 = xh2 = 270; /* cosfi = -VERY_SMALL; */
     } else {
-      xh1 = atand(sqrt (3.0) / cosfi);
+      // triangle formed by equator, prime vertical, great circle 
+      // through P11, S and N
+      // with right angle between prime vertical and great circle
+      // side length xh1 on equ, 60 on prime vertical, angle fi between
+      // tan xh1 = tan 60 / cos fi = √3 / cos fi
+      xh1 = atand(sqrt (3.0) / cosfi);	
+      // side length xh2 on equ, 30° on prime vertical, angle fi between
+      // tan xh2 = tan 30 / cos fi = 1/√3 / cos fi
       xh2 = atand(1 / sqrt (3.0) / cosfi);
     }
     hsp->cusp[11] = Asc1(th + 90 - xh1, fh1, sine, cose);
     hsp->cusp[12] = Asc1(th + 90 - xh2, fh2, sine, cose);
-    if (hsy == 'H') 
-      hsp->cusp[1] = Asc1(th + 90, fi, sine, cose);
     hsp->cusp[2] = Asc1(th + 90 + xh2, fh2, sine, cose);
     hsp->cusp[3] = Asc1(th + 90 + xh1, fh1, sine, cose);
     if (hsp->do_hspeed) {
       hsp->cusp_speed[11] = AscDash(th + 90 - xh1, fh1, sine, cose);
       hsp->cusp_speed[12] = AscDash(th + 90 - xh2, fh2, sine, cose);
-      if (hsy == 'H') 
-	hsp->cusp_speed[1] = AscDash(th + 90, fi, sine, cose);
       hsp->cusp_speed[2] = AscDash(th + 90 + xh2, fh2, sine, cose);
       hsp->cusp_speed[3] = AscDash(th + 90 + xh1, fh1, sine, cose);
     }
@@ -1073,21 +1073,78 @@ static int CalcH(
         }
       }
     }
-    if (hsy == 'H') {
-      for (i = 1; i <= 3; i++)
-        hsp->cusp[i] = swe_degnorm(hsp->cusp[i] + 180);
-      for (i = 11; i <= 12; i++)
-        hsp->cusp[i] = swe_degnorm(hsp->cusp[i] + 180);
-      /* restore fi and th */
-      if (fi > 0)
-        fi = 90 - fi;
+    break;
+  case 'H': /* Horizon or Azimut system, similar to Campanus calulation */
+    if (fi > 0)
+      fi = 90 - fi;
+    else
+      fi = -90 - fi;
+    /* equator */
+    if (fabs(fabs(fi) - 90) < VERY_SMALL) {
+      if (fi < 0)
+	fi = -90 + VERY_SMALL;
       else
-	fi = -90 - fi;
-      th = swe_degnorm(th + 180);
+	fi = 90 - VERY_SMALL;
+    } 
+    th = swe_degnorm(th + 180);
+    fh1 = asind(sind (fi) / 2);
+    fh2 = asind(sqrt (3.0) / 2 * sind(fi)); 
+    cosfi = cosd(fi);
+    if (fabs(cosfi) == 0) {	/* '==' should be save! */ 
+      if (fi > 0)
+	xh1 = xh2 = 90; /* cosfi = VERY_SMALL; */
+      else
+	xh1 = xh2 = 270; /* cosfi = -VERY_SMALL; */
+    } else {
+      // triangle formed by equator, prime vertical, declination circle,
+      // with right angle between equator and declination circle:
+      // side length xh1 on equ, 60 on prime vertical, angle fi between
+      // tan xh1 = tan 60 / cos fi = √3 / cos fi
+      xh1 = atand(sqrt (3.0) / cosfi);	
+      // side length xh2 on equ, 30° on prime vertical, angle fi between
+      // tan xh2 = tan 30 / cos fi = 1/√3 / cos fi
+      xh2 = atand(1 / sqrt (3.0) / cosfi);
+    }
+    hsp->cusp[11] = Asc1(th + 90 - xh1, fh1, sine, cose);
+    hsp->cusp[12] = Asc1(th + 90 - xh2, fh2, sine, cose);
+    hsp->cusp[1] = Asc1(th + 90, fi, sine, cose);
+    hsp->cusp[2] = Asc1(th + 90 + xh2, fh2, sine, cose);
+    hsp->cusp[3] = Asc1(th + 90 + xh1, fh1, sine, cose);
+    if (hsp->do_hspeed) {
+      hsp->cusp_speed[11] = AscDash(th + 90 - xh1, fh1, sine, cose);
+      hsp->cusp_speed[12] = AscDash(th + 90 - xh2, fh2, sine, cose);
+      hsp->cusp_speed[1] = AscDash(th + 90, fi, sine, cose);
+      hsp->cusp_speed[2] = AscDash(th + 90 + xh2, fh2, sine, cose);
+      hsp->cusp_speed[3] = AscDash(th + 90 + xh1, fh1, sine, cose);
+    }
+    /* within polar circle, when mc sinks below horizon and 
+	 * ascendant changes to western hemisphere, all cusps
+     * must be added 180 degrees. 
+     * houses will be in clockwise direction */
+    if (fabs(fi) >= 90 - ekl) {  /* within polar circle */
       acmc = swe_difdeg2n(hsp->ac, hsp->mc);
       if (acmc < 0) {
         hsp->ac = swe_degnorm(hsp->ac + 180);
+        hsp->mc = swe_degnorm(hsp->mc + 180);
+	for (i = 1; i <= 12; i++) {
+	  if (i >= 4 && i < 10) continue;
+	  hsp->cusp[i] = swe_degnorm(hsp->cusp[i] + 180);
+        }
       }
+    }
+    for (i = 1; i <= 3; i++)
+      hsp->cusp[i] = swe_degnorm(hsp->cusp[i] + 180);
+    for (i = 11; i <= 12; i++)
+      hsp->cusp[i] = swe_degnorm(hsp->cusp[i] + 180);
+    /* restore fi and th */
+    if (fi > 0)
+      fi = 90 - fi;
+    else
+      fi = -90 - fi;
+    th = swe_degnorm(th + 180);
+    acmc = swe_difdeg2n(hsp->ac, hsp->mc);
+    if (acmc < 0) {
+      hsp->ac = swe_degnorm(hsp->ac + 180);
     }
     break;
   case 'I': /* Sunshine houses, solution Treindl */
@@ -1115,6 +1172,74 @@ static int CalcH(
       goto porphyry;
     }
     hsp->do_interpol = hsp->do_hspeed;
+    break;
+  case 'J': /* Savard's supposed Albategnius houses */
+    // house 11: latitude circle at 2/3 fi intersects prime meridian at p11.
+    // house 12: latitude circle at fi / 3 intersects prime meridian at p12.
+    // triangle X-p12-E formed by equator, prime vertical, declination circle,
+    // side length xs1 or xs2 on prime vertical, 2/3 fi or fi/3  on declination circle,
+    // angle fi between prime vertical and equator at E, right angle between equator
+    // and declination circle.
+    // sin b = sin B sin c, with b = 1/3 or 2/3 fi, B = fi
+    sinfi = sind(fi);
+    cosfi = cosd(fi);
+    if (fabs(fi) < VERY_SMALL) {	
+      xs2 = 1 / 3.0;
+      xs1 = 2 / 3.0;
+    } else {
+      xs2 = sind(fi / 3) / sinfi;	
+      xs1 = sind(2 * fi / 3) / sinfi;
+    }
+    xs2 = asind(xs2);
+    xs1 = asind(xs1);
+    // now consider triangle great circle through h11, equ, prime vertical, with
+    // right angle between prime vertical and great circle
+    // side length xh1 on equ, xs1 on prime vertical, angle fi between
+    // tan xh1 = tan xs1 / cos fi 
+    if (cosfi == 0) {
+      if (fi > 0)
+	xh1 = xh2 = 90; 
+      else
+	xh1 = xh2 = 270;
+    } else {
+      xh1 = atand(tand(xs1) / cosfi);	
+      xh2 = atand(tand(xs2) / cosfi);	
+    }
+    // Pole height:
+    // great circle S - p11 - N has angle 90 - xs1 on North or South point,
+    // north point to south point go through these points and intersect ecliptic.
+    // pole height = shortest distance of plane from North pole,
+    // measured along declination circle.
+    // NP = North Pole, N = north point, H11 = house 11 point in prime vertical
+    // triangle NP - N - h11 , angle xs1 at N, side fi between NP and N
+    // sin fh1 = sin fi * sin (90 - xs1),
+    fh1 = asind(sind (fi) * sind(90 - xs1));
+    fh2 = asind(sind (fi) * sind(90 - xs2));
+    hsp->cusp[12] = Asc1(th + 90 - xh2, fh2, sine, cose);
+    hsp->cusp[11] = Asc1(th + 90 - xh1, fh1, sine, cose);
+    hsp->cusp[2] = Asc1(th + 90 + xh2, fh2, sine, cose);
+    hsp->cusp[3] = Asc1(th + 90 + xh1, fh1, sine, cose);
+    if (hsp->do_hspeed) {
+      hsp->cusp_speed[11] = AscDash(th + 90 - xh1, fh1, sine, cose);
+      hsp->cusp_speed[12] = AscDash(th + 90 - xh2, fh2, sine, cose);
+      hsp->cusp_speed[3] = AscDash(th + 90 + xh1, fh1, sine, cose);
+      hsp->cusp_speed[2] = AscDash(th + 90 + xh2, fh2, sine, cose);
+    }
+    /* within polar circle, when mc sinks below horizon and 
+	 * ascendant changes to western hemisphere, all cusps
+     * must be added 180 degrees. 
+     * houses will be in clockwise direction */
+    if (fabs(fi) >= 90 - ekl) {  /* within polar circle */
+      acmc = swe_difdeg2n(hsp->ac, hsp->mc);
+      if (acmc < 0) {
+        hsp->ac = swe_degnorm(hsp->ac + 180);
+        hsp->mc = swe_degnorm(hsp->mc + 180);
+	for (i = 1; i <= 12; i++) {
+	  if (i >= 4 && i < 10) continue;
+	  hsp->cusp[i] = swe_degnorm(hsp->cusp[i] + 180);
+        }
+      }
+    }
     break;
   case 'K': /* Koch houses */
     if (fabs(fi) >= 90 - ekl) {  /* within polar circle */
@@ -1448,39 +1573,44 @@ porphyry:
     hsp->do_interpol = hsp->do_hspeed;
     break; }
   case 'B': {	/* Alcabitius */
-    /* created by Alois 17-sep-2000, followed example in Matrix
-       electrical library. The code reproduces the example!
-       I think the Alcabitius code in Walter Pullen's Astrolog 5.40
-       is wrong, because he remains in RA and forgets the transform to
-       the ecliptic. */
-    double dek, r, sna, sda, sn3, sd3;
-    acmc = swe_difdeg2n(hsp->ac, hsp->mc);
-    if (acmc < 0) {
-      hsp->ac = swe_degnorm(hsp->ac + 180);
-      hsp->cusp[1] = hsp->ac;
+      // created by Alois 17-sep-2000, followed example in Matrix
+      // electrical library. The code reproduces the example!
+      // This corresponds to Munkasey 'The Alcibitius Semiarc House System'
+      // as described in his Astrological House Formulae'
+      double dek, r, sna, sda, sn3, sd3;
       acmc = swe_difdeg2n(hsp->ac, hsp->mc);
-    }
-    dek = asind(sind(hsp->ac) * sine);	/* declination of Ascendant */
-    /* must treat the case fi == 90 or -90 */
-    r = -tanfi * tand(dek);
-    /* must treat the case of abs(r) > 1; probably does not happen
-     * because dek becomes smaller when fi is large, as ac is close to
-     * zero Aries/Libra in that case.
-     */
-    sda = acos(r) * RADTODEG;	/* semidiurnal arc, measured on equator */
-    sna = 180 - sda;		/* complement, seminocturnal arc */
-    sd3 = sda / 3;
-    sn3 = sna / 3;
-    rectasc = swe_degnorm(th + sd3);	/* cusp 11 */
-    /* project rectasc onto eclipitic with pole height 0, i.e. along the
-    declination circle */
-    hsp->cusp[11] = Asc1(rectasc, 0, sine, cose);
-    rectasc = swe_degnorm(th + 2 * sd3);	/* cusp 12 */
-    hsp->cusp[12] = Asc1(rectasc, 0, sine, cose);
-    rectasc = swe_degnorm(th + 180 - 2 * sn3);	/* cusp 2 */
-    hsp->cusp[2] = Asc1(rectasc, 0, sine, cose);
-    rectasc = swe_degnorm(th + 180 -  sn3);	/* cusp 3 */
-    hsp->cusp[3] = Asc1(rectasc, 0, sine, cose);
+      if (acmc < 0) {
+	hsp->ac = swe_degnorm(hsp->ac + 180);
+	hsp->cusp[1] = hsp->ac;
+	acmc = swe_difdeg2n(hsp->ac, hsp->mc);
+      }
+      dek = asind(sind(hsp->ac) * sine);	/* declination of Ascendant */
+      // triangle horizon - decl circle - equator, right angle between equ and 
+      // decl circle, angle 90 - fi between horizon and equator A, decl = a
+      // tan a = sin b tan A, sin b = tan decl * cot (90-fi) = tan decl * tan fi
+      // We want semidiurnal circle  90 + b; cos (90 + b) = - sin b = r = -tan decl * tan fi
+      // sda = arccos r
+      // case fi == 90 or -90 is dealt with at entry into function
+      r = -tanfi * tand(dek);
+      // must treat the case of abs(r) > 1; happens very rarely
+      // because dek becomes smaller when fi is large, as ac is close to
+      // zero Aries/Libra in that case.
+      if (r > 1) r = 1;
+      if (r < -1) r = -1;
+      sda = acosd(r);	// semidiurnal arc, measured on equator 
+      sna = 180 - sda;	// complement, seminocturnal arc
+      sd3 = sda / 3;
+      sn3 = sna / 3;
+      rectasc = swe_degnorm(th + sd3);	/* cusp 11 */
+      // project rectasc onto eclipitic with pole height 0, i.e. along the
+      // declination circle 
+      hsp->cusp[11] = Asc1(rectasc, 0, sine, cose);
+      rectasc = swe_degnorm(th + 2 * sd3);	/* cusp 12 */
+      hsp->cusp[12] = Asc1(rectasc, 0, sine, cose);
+      rectasc = swe_degnorm(th + 180 - 2 * sn3);	/* cusp 2 */
+      hsp->cusp[2] = Asc1(rectasc, 0, sine, cose);
+      rectasc = swe_degnorm(th + 180 -  sn3);	/* cusp 3 */
+      hsp->cusp[3] = Asc1(rectasc, 0, sine, cose);
     }
     hsp->do_interpol = hsp->do_hspeed;
     break;
@@ -1846,7 +1976,7 @@ porphyry:
     }
     break;
   } /* end switch */
-  if (hsy != 'G' && hsy != 'Y' && toupper(hsy) != 'I') {
+  if (hsy != 'G' && hsy != 'Y' && toupper(hsy) != 'I' ) {
     hsp->cusp[4] = swe_degnorm(hsp->cusp[10] + 180);
     hsp->cusp[5] = swe_degnorm(hsp->cusp[11] + 180);
     hsp->cusp[6] = swe_degnorm(hsp->cusp[12] + 180);
@@ -1910,13 +2040,15 @@ porphyry:
   /* "polar ascendant" M. Munkasey */
   hsp->polasc = Asc1(th - 90, fi, sine, cose);
   if (hsp->do_speed) hsp->polasc_speed = AscDash(th - 90, fi, sine, cose);
-#if 0
-  test_Asc1();
-#endif
   return retc;
 } /* procedure houses */
 
-/******************************/
+/*****
+ * oblique triangle formed by: great circle with pole height f, ecliptic and equator,
+ * x = intersection equator - great circle.
+ * return crossing of ecliptic with great circle.
+ * Prepare quadrants before doing the work in Asc2.
+ */
 static double Asc1(double x1, double f, double sine, double cose) 
 { 
   int n;
@@ -1949,108 +2081,21 @@ static double Asc1(double x1, double f, double sine, double cose)
   return ass;
 }  /* Asc1 */
 
-// derivative of Asc1, computes speed
-// code crontributed by Graham Dawson
-static double AscDash(double x, double f, double sine, double cose)
-{
-  double cosx = cosd(x);
-  double sinx = sind(x);
-  double sinx2 = sinx * sinx;
-  double c = cose * cosx - tand(f) * sine;
-  double d = sinx2 + c * c;
-  double dudt;
-  if (d > VERY_SMALL) {
-      dudt = (cosx * c + cose * sinx2) / d;
-  } else {
-      dudt = 0.0; //  When we are on axis of ecliptic
-  }
-  return dudt * ARMCS;	// 360.985647366;
-}
-
-
-#if 0
-/******************************/
-static double Asc1_old(double x1, double f, double sine, double cose) 
-{ 
-  int n;
-  double ass;
-  if (f == -90) f += VERY_SMALL / 1000;        // avoid exact pole 90, as tan() goes infinite
-  if (f == 90) f -= VERY_SMALL / 1000;
-  x1 = swe_degnorm(x1);
-  n  = (int) ((x1 / 90) + 1);
-  if (n == 1)
-    ass = ( Asc2(x1, f, sine, cose));
-  else if (n == 2) 
-    ass = (180 - Asc2(180 - x1, - f, sine, cose));
-  else if (n == 3)
-    ass = (180 + Asc2(x1 - 180, - f, sine, cose));
-  else
-    ass = (360 - Asc2(360- x1,  f, sine, cose));
-  ass = swe_degnorm(ass);
-  if (fabs(ass - 90) < VERY_SMALL)	/* rounding, e.g.: if */
-	ass = 90;				/* fi = 0 & st = 0, ac = 89.999... */
-  if (fabs(ass - 180) < VERY_SMALL)
-    ass = 180;
-  if (fabs(ass - 270) < VERY_SMALL)	/* rounding, e.g.: if */
-    ass = 270;				/* fi = 0 & st = 0, ac = 89.999... */
-  if (fabs(ass - 360) < VERY_SMALL)
-    ass = 0;
-  return ass;
-}  /* Asc1 */
-
-/******************************/
-static double Asc1_old_old (double x1, double f, double sine, double cose) 
-{ 
-  int n;
-  double ass;
-  x1 = swe_degnorm(x1);
-  n  = (int) ((x1 / 90) + 1);
-  if (n == 1)
-    ass = ( Asc2 (x1, f, sine, cose));
-  else if (n == 2) 
-    ass = (180 - Asc2 (180 - x1, - f, sine, cose));
-  else if (n == 3)
-    ass = (180 + Asc2 (x1 - 180, - f, sine, cose));
-  else
-    ass = (360 - Asc2 (360- x1,  f, sine, cose));
-  ass = swe_degnorm(ass);
-  if (fabs(ass - 90) < VERY_SMALL)	/* rounding, e.g.: if */
-	ass = 90;				/* fi = 0 & st = 0, ac = 89.999... */
-  if (fabs(ass - 180) < VERY_SMALL)
-    ass = 180;
-  if (fabs(ass - 270) < VERY_SMALL)	/* rounding, e.g.: if */
-    ass = 270;				/* fi = 0 & st = 0, ac = 89.999... */
-  if (fabs(ass - 360) < VERY_SMALL)
-    ass = 0;
-  return ass;
-}  /* Asc1 */
-
-static void test_Asc1()
-{
-  double armc, dlat, eps = 23.44, asc1, asc1_old, sine, cose;
-  sine = sind(eps);
-  cose = cosd(eps);
-  fprintf(stderr, "Test Asc1() <-> Asc1_old()\n");
-  for (dlat = -90; dlat <= 90; dlat++) {
-    for (armc = 0; armc <= 360; armc++) {
-      asc1 = Asc1(armc, dlat, sine, cose);
-      asc1_old = Asc1_old_old(armc, dlat, sine, cose);
-      if (asc1 != asc1_old)
-        fprintf(stderr, "armc=%f, lat=%f, Asc1: %.16f <-> Asc1_old: %.16f\n", armc, dlat, asc1, asc1_old);
-    }
-  }
-
-}
-#endif
 
 /*
  * x in range 0..90
  * f in range -90 .. +90
  * sine, cose around e=23°
+ * oblique triangle formed by: great circle with pole height f, ecliptic and equator,
+ * x = intersection equator - great circle.
+ * return crossing of ecliptic with great circle.
  */
 static double Asc2(double x, double f, double sine, double cose) 
 {
   double ass, sinx;
+  // from https://en.wikipedia.org/wiki/Spherical_trigonometry CT5
+  // cot c sin a = cot C sin B + cos a cos B, with B = ecl, a = x, C = 90 +f
+  // cot 90 + f = - tan f
   ass = - tand(f) * sine + cose * cosd(x);
   if (fabs(ass) < VERY_SMALL)
     ass = 0;
@@ -2068,12 +2113,31 @@ static double Asc2(double x, double f, double sine, double cose)
     else
       ass = 90;
   } else {
+    // resolve ass = sin x cot c; cot c = ass / sini x; tan c = sin x / ass
     ass = atand(sinx / ass);
   }
   if (ass < 0)
     ass = 180 + ass;
   return (ass);
 } /* Asc2 */
+
+// derivative of Asc1, computes speed
+// code contributed by Graham Dawson
+static double AscDash(double x, double f, double sine, double cose)
+{
+  double cosx = cosd(x);
+  double sinx = sind(x);
+  double sinx2 = sinx * sinx;
+  double c = cose * cosx - tand(f) * sine;
+  double d = sinx2 + c * c;
+  double dudt;
+  if (d > VERY_SMALL) {
+      dudt = (cosx * c + cose * sinx2) / d;
+  } else {
+      dudt = 0.0; //  When we are on axis of ecliptic
+  }
+  return dudt * ARMCS;	// 360.985647366;
+}
 
 static double armc_to_mc(double armc, double eps)
 {
@@ -2148,8 +2212,8 @@ double CALL_CONV swe_house_pos(
   double xp[6], xeq[6], ra, de, mdd, mdn, sad, san;
   double hpos, sinad, ad, a, admc, adp, samc, asc, mc, acmc, tant;
   //double demc;
-  double fh, ra0, tanfi, fac, dfac, tanx;
-  double x[3], xasc[3], raep, raaz, oblaz, xtemp; /* BK 21.02.2006 */
+  double fh, ra0, tanfi, sinfi, fac, dfac, tanx;
+  double x[3], xasc[3], xs1, xs2, raep, raaz, oblaz, xtemp; /* BK 21.02.2006 */
   double hcusp[37], ascmc[10];
   double sine = sind(eps);
   double cose = cosd(eps);
@@ -2158,42 +2222,42 @@ double CALL_CONV swe_house_pos(
   double dsun = 0, darmc, harmc, y, sinpsi, sa;
   AS_BOOL is_western_half = FALSE;
   hsys = toupper(hsys);
-if (1) {
-  /* input is a house position: no calculation is required */
-  ascmc[9] = 99;// dirty hack. Sunshine house system needs sun declination
-  		// which we do not know. If it sees ascmc[9] == 99, it uses
-		// the one is saved from last call. can lead to bugs, but can 
-		// also solve many problems.
-  if (swe_houses_armc_ex2(armc, geolat, eps, hsys, hcusp, ascmc, NULL, NULL, serr) == ERR) {
-    if (serr != NULL)
-      sprintf(serr, "swe_house_pos(): failed for system %c", hsys);
-  } else {
-    hpos = 0;
-    for (i = 1; i <= 12; i++) {
-      if (fabs(swe_difdeg2n(xpin[0], hcusp[i])) < MILLIARCSEC && xpin[1] == 0) {
-	hpos = (double) i;
+  if (1) {
+    /* input is a house cusp: no calculation is required */
+    ascmc[9] = 99;// dirty hack. Sunshine house system needs sun declination
+		  // which we do not know. If it sees ascmc[9] == 99, it uses
+		  // the one is saved from last call. can lead to bugs, but can 
+		  // also solve many problems.
+    if (swe_houses_armc_ex2(armc, geolat, eps, hsys, hcusp, ascmc, NULL, NULL, serr) == ERR) {
+      if (serr != NULL)
+	sprintf(serr, "swe_house_pos(): failed for system %c", hsys);
+    } else {
+      hpos = 0;
+      for (i = 1; i <= 12; i++) {
+	if (fabs(swe_difdeg2n(xpin[0], hcusp[i])) < MILLIARCSEC && xpin[1] == 0) {
+	  hpos = (double) i;
+	}
       }
-    }
-    for (i = 1; i <= 12; i += 3) {
-      if (fabs(swe_difdeg2n(xpin[0], hcusp[i])) < MILLIARCSEC && xpin[1] == 0) {
-	xp[0] = (double) i;
+      for (i = 1; i <= 12; i += 3) {
+	if (fabs(swe_difdeg2n(xpin[0], hcusp[i])) < MILLIARCSEC && xpin[1] == 0) {
+	  xp[0] = (double) i;
+	}
       }
-    }
-    if (hpos > 0)
-      return hpos;
-    // for Sunshine houses: declination of Sun
-    if (hsys == 'I')
-      dsun = ascmc[9];  
-    // for APC houses: declination of ascendant into dsun
-    if (hsys == 'Y') {
-      xeq[0] = ascmc[0];
-      xeq[1] = 0;
-      xeq[2] = 1;
-      swe_cotrans(xeq, xeq, -eps);
-      dsun = xeq[1]; 
+      if (hpos > 0)
+	return hpos;
+      // for Sunshine houses: declination of Sun
+      if (hsys == 'I')
+	dsun = ascmc[9];  
+      // for APC houses: declination of ascendant into dsun
+      if (hsys == 'Y') {
+	xeq[0] = ascmc[0];
+	xeq[1] = 0;
+	xeq[2] = 1;
+	swe_cotrans(xeq, xeq, -eps);
+	dsun = xeq[1]; 
+      }
     }
   }
-}
   AS_BOOL is_above_hor = FALSE;
   AS_BOOL is_invalid = FALSE;
   AS_BOOL is_circumpolar = FALSE;
@@ -2321,37 +2385,6 @@ if (1) {
       hpos = hpos / 30.0 + 1;
     }
       break;
-#if 0
-    /* old version of Koch method */
-    case 'K':
-      demc = atand(sind(armc) * tand(eps));
-      /* if body is within circumpolar region, error */
-      if (90 - fabs(geolat) <= fabs(de)) {
-        if (serr != NULL)
-          strcpy(serr, "no Koch house position, because planet is circumpolar.");
-        xp[0] = 0;
-	hpos = 0;	/* Error */
-      } else if (90 - fabs(geolat) <= fabs(demc)) {
-	if (serr != NULL)
-	  strcpy(serr, "no Koch house position, because mc is circumpolar.");
-        xp[0] = 0;
-	hpos = 0;	/* Error */
-      } else {
-        admc = asind(tand(eps) * tand(geolat) * sind(armc));
-        adp = asind(tand(geolat) * tand(de));
-	samc = 90 + admc;
-        if (mdd >= 0) {	/* east */
-          xp[0] = swe_degnorm(((mdd - adp + admc) / samc - 1) * 90);
-	} else {
-	  xp[0] = swe_degnorm(((mdd + 180 + adp + admc) / samc + 1) * 90);
-	}
-	/* to make sure that a call with a house cusp position returns
-	 * a value within the house, 0.001" is added */
-	xp[0] = swe_degnorm(xp[0] + MILLIARCSEC);
-	hpos = xp[0] / 30.0 + 1;
-      }
-      break;
-#endif
     /* version of Koch method: do calculations within circumpolar circle,
      * if possible; make sure house positions 4 - 9 only appear on western
      * hemisphere */
@@ -2373,16 +2406,9 @@ if (1) {
       else {
 	adp = asind(tand(geolat) * tand(de));
       }
-#if 0
-      if (fabs(adp) == 90)
-        is_invalid = TRUE; /* omit this to use the above values */
-#endif
       admc = tand(eps) * tand(geolat) * sind(armc);
       /* midheaven is circumpolar */
       if (fabs(admc) > 1) {
-#if 0
-        is_invalid = TRUE; /* omit this line to use the below values */
-#endif
 	if (admc > 1)
 	  admc = 1;
 	else
@@ -2427,11 +2453,75 @@ if (1) {
       break;
     case 'C': // Campanus
       xeq[0] = swe_degnorm(mdd - 90);
+      // we measure on equator from east point towards IC.
+      // transformation to prime vertical, with these coordinate references
+      // EP = 0, nadir = 90, WP = 180, Zenith = 270
       swe_cotrans(xeq, xp, -geolat);
       /* to make sure that a call with a house cusp position returns
        * a value within the house, 0.001" is added */
       xp[0] = swe_degnorm(xp[0] + MILLIARCSEC);
       hpos = xp[0] / 30.0 + 1;
+      break;
+    case 'J': // Savard-A
+      sinfi = sind(geolat);
+      if (fabs(geolat) < VERY_SMALL) {	
+	xs2 = 1 / 3.0;
+	xs1 = 2 / 3.0;
+      } else {
+	xs2 = sind(geolat / 3) / sinfi;	
+	xs1 = sind(2 * geolat / 3) / sinfi;
+      }
+      xs2 = asind(xs2);
+      xs1 = asind(xs1);
+      // xs1 and xs2 always in >= 0 < 90
+      // house borders on prime vertical are, measured from EP downwards
+      // h1 = 0, h4 = 90, h7 = 180, h10 = 270
+      // h2 = xs2, h3 = xs1, h12 = 360 - xs2, h11 = 360 - xs1
+      // h5 = h11 - 180, h6 = h12 - 180, h8 = h2 + 180, h9 = h3 + 180
+      hcusp[1] = 0;
+      hcusp[2] = xs2;
+      hcusp[3] = xs1;
+      hcusp[4] = 90;
+      hcusp[5] = 180 - xs1;
+      hcusp[6] = 180 - xs2;
+      hcusp[7] = 180;
+      hcusp[8] = 180 + xs2;
+      hcusp[9] = 180 + xs1;
+      hcusp[10] = 270;
+      hcusp[11] = 360 - xs1;
+      hcusp[12] = 360 - xs2;
+      xeq[0] = swe_degnorm(mdd - 90);
+      swe_cotrans(xeq, xp, -geolat);
+      a = xp[0];
+      if (swe_difdeg2n(hcusp[6], hcusp[1]) > 0) {
+	d = swe_degnorm(a - hcusp[1]);
+	for (i = 1; i <= 12; i++) {
+	  j = i + 1;
+	  if (j > 12) 
+	    c2 = 360;
+	  else 
+	    c2 = swe_degnorm(hcusp[j] - hcusp[1]);
+	  if (d < c2) break;
+	}
+	c1 = swe_degnorm(hcusp[i] - hcusp[1]);
+      } else {  // houses retrograde
+	d = swe_degnorm(hcusp[1] - a);
+	for (i = 1; i <= 12; i++) {
+	  j = i + 1;
+	  if (j > 12) 
+	    c2 = 360;
+	  else 
+	    c2 = swe_degnorm(hcusp[1] - hcusp[j]);
+	  if (d < c2) break;
+	}
+	c1 = swe_degnorm(hcusp[1] - hcusp[i]);
+      }
+      hsize = c2 - c1;
+      if (hsize == 0) {
+	hpos = i;
+      } else {
+	hpos = i + (d - c1) / hsize;
+      }
       break;
     case 'U': /* Krusinski-Pisa-Goelzer */
       if (fabs(geolat) < VERY_SMALL) {	/* code below does not like geolat 0 */

--- a/csrc/sweodef.h
+++ b/csrc/sweodef.h
@@ -74,13 +74,17 @@
 # define MY_TRUE 1	/* for use in other defines, before TRUE is defined */
 # define MY_FALSE 0	/* for use in other defines, before TRUE is defined */
 
+#ifdef __CYGWIN__	// following T. Mack Jan/July 2021
+# undef __GNUC__
+#endif
+
 /* TLS support
  *
  * Sun Studio C/C++, IBM XL C/C++, GNU C and Intel C/C++ (Linux systems) -> __thread
  * Borland, VC++ -> __declspec(thread)
  */
 #if !defined(TLSOFF) && !defined( __APPLE__ ) && !defined(WIN32) && !defined(DOS32)
-#if defined( __GNUC__ )
+#if defined( __GNUC__ ) || defined( __CYGWIN__ ) 
 #define TLS     __thread
 #else
 #define TLS     __declspec(thread)

--- a/csrc/sweph.c
+++ b/csrc/sweph.c
@@ -4678,7 +4678,7 @@ static int read_const(int ifno, char *serr)
     /* MPC number and name; will be analyzed below:
      * search "asteroid name" */
     while(*sp == ' ') sp++;
-    while(isdigit(*sp)) sp++;
+    while(isdigit((int) *sp)) sp++;
     sp++;
     i = (int) (sp - s);
     strncpy(sastnam, s, lastnam+i);	// fixed 19-nov-19
@@ -8399,3 +8399,311 @@ const char *CALL_CONV swe_get_current_file_data(int ifno, double *tfstart, doubl
   return pfp->fnam;
 }
 
+#define CROSS_PRECISION (1 / 3600000.0) 	// one milliarc sec
+
+/*************************************************
+ * compute Sun'scrossing over some longitude
+ * flag covers the following bits as used by swe_calc():
+   SEFLG_HELCTR 		0 = geocentric, SUN, 1 = heliocentric, EARTH
+   SEFLG_TRUEPOS 	   	0 = apparent positions, 1 = true positions
+   SEFLG_NONUT 		0 = do nutation (true equinox of date)
+ * returns juldate of the next crossing, with jd > jd_et
+ * The returned time is ephemeris time; to get UT we must do
+ * jd_ut = jd - deltat(jd) or use swe_solcross_ut.
+ * Errors are indicated by returning a jd < jd_et!
+ *************************************************/
+double CALL_CONV swe_solcross(double x2cross, double jd_et, int flag, char *serr)
+{
+  double x[6], xlp, dist;
+  double jd;
+  int ipl = SE_SUN;
+  /*
+   * compute the SUN at start date, and then estimate the crossing date
+   */
+  flag |= SEFLG_SPEED;
+  if (swe_calc(jd_et, ipl, flag, x, serr) < 0) 
+    return jd_et - 1;
+  xlp = 360.0 / 365.24;	/* mean solar speed */
+  dist = swe_degnorm(x2cross - x[0]);
+  jd = jd_et + dist / xlp;
+  for(;;) {
+    if (swe_calc(jd, ipl, flag, x, serr) < 0) 
+      return jd_et - 1;
+    dist = swe_difdeg2n(x2cross, x[0]);
+    jd += dist / x[3];
+    if (fabs(dist) < CROSS_PRECISION) break;
+  } 
+  return jd;
+}
+
+/*************************************************
+ * compute Sun'scrossing over some longitude, in UT
+ * flag covers the following bits as used by swe_calc():
+   SEFLG_HELCTR 		0 = geocentric, SUN, 1 = heliocentric, EARTH
+   SEFLG_TRUEPOS 	   	0 = apparent positions, 1 = true positions
+   SEFLG_NONUT 		0 = do nutation (true equinox of date)
+ * returns juldate of the next crossing, with jd > jd_ut
+ * The returned time is universal time;
+ * Errors are indicated by returning a jd < jd_ut!
+ *************************************************/
+double CALL_CONV swe_solcross_ut(double x2cross, double jd_ut, int flag, char *serr)
+{
+  double x[6], xlp, dist;
+  double jd;
+  int ipl = SE_SUN;
+  /*
+   * compute the SUN at start date, and then estimate the crossing date
+   */
+  flag |= SEFLG_SPEED;
+  if (swe_calc_ut(jd_ut, ipl, flag, x, serr) < 0) 
+    return jd_ut - 1;
+  xlp = 360.0 / 365.24;	/* mean solar speed */
+  dist = swe_degnorm(x2cross - x[0]);
+  jd = jd_ut + dist / xlp;
+  for(;;) {
+    if (swe_calc_ut(jd, ipl, flag, x, serr) < 0) 
+      return jd_ut - 1;
+    dist = swe_difdeg2n(x2cross, x[0]);
+    jd += dist / x[3];
+    if (fabs(dist) < CROSS_PRECISION) break;
+  } 
+  return jd;
+}
+
+/*************************************************
+ * compute Moon's crossing over some longitude
+ * flag covers the following bits as used by swe_calc():
+   SEFLG_TRUEPOS 	   	0 = apparent positions, 1 = true positions
+   SEFLG_NONUT 		0 = do nutation (true equinox of date)
+ * returns juldate of the next crossing, with jd > jd_et
+ * The returned time is ephemeris time; to get UT we must do
+ * jd_ut = jd - deltat(jd);
+ * Errors are indicated by returning a jd < jd_et!
+ *************************************************/
+double CALL_CONV swe_mooncross(double x2cross, double jd_et, int flag, char *serr)
+{
+  double x[6], xlp, dist;
+  double jd;
+  int ipl = SE_MOON;
+  /*
+   * compute the SUN at start date, and then estimate the crossing date
+   */
+  flag |= SEFLG_SPEED;
+  if (swe_calc(jd_et, ipl, flag, x, serr) < 0) 
+    return jd_et - 1;
+  xlp = 360.0 / 27.32;	/* mean lunar speed */
+  dist = swe_degnorm(x2cross - x[0]);
+  jd = jd_et + dist / xlp;
+  for(;;) {
+    if (swe_calc(jd, ipl, flag, x, serr) < 0) 
+      return jd_et - 1;
+    dist = swe_difdeg2n(x2cross, x[0]);
+    jd += dist / x[3];
+    if (fabs(dist) < CROSS_PRECISION) break;
+  } 
+  return jd;
+}
+
+/*************************************************
+ * compute Moon's crossing over some longitude
+ * flag covers the following bits as used by swe_calc_ut():
+   SEFLG_TRUEPOS 	0 = apparent positions, 1 = true positions
+   SEFLG_NONUT 		0 = do nutation (true equinox of date)
+   SEFLG_SIDEREAL       0 = do tropical
+ * returns juldate of the next crossing, with jd > jd_ut
+ * The returned time is UT
+ * Errors are indicated by returning a jd < jd_ut!
+ * If sidereal is chosen, default mode is Fagan/Bradley. For different aynamshas,
+ * swe_set_sid_mode() must be called first.
+ *************************************************/
+double CALL_CONV swe_mooncross_ut(double x2cross, double jd_ut, int flag, char *serr)
+{
+  double x[6], xlp, dist;
+  double jd;
+  int ipl = SE_MOON;
+  /*
+   * compute the SUN at start date, and then estimate the crossing date
+   */
+  flag |= SEFLG_SPEED;
+  if (swe_calc_ut(jd_ut, ipl, flag, x, serr) < 0) 
+    return jd_ut - 1;
+  xlp = 360.0 / 27.32;	/* mean lunar speed */
+  dist = swe_degnorm(x2cross - x[0]);
+  jd = jd_ut + dist / xlp;
+  for(;;) {
+    if (swe_calc_ut(jd, ipl, flag, x, serr) < 0) 
+      return jd_ut - 1;
+    dist = swe_difdeg2n(x2cross, x[0]);
+    jd += dist / x[3];
+    if (fabs(dist) < CROSS_PRECISION) break;
+  } 
+  return jd;
+}
+
+/*************************************************
+ * compute next Moon crossing over node, by finding zero latitude crossing
+ * returns juldate of the next crossing, with jd > jd_et
+ * The returned time is ephemeris time; to get UT we must do
+ * jd_ut = jd - deltat(jd);
+ * Errors are indicated by returning a jd < jd_et!
+ *************************************************/
+double CALL_CONV swe_mooncross_node(double jd_et, int flag, double *xlon, double *xla, char *serr)
+{
+  double x[6], xlat, dist;
+  double jd;
+  int ipl = SE_MOON;
+  flag |= SEFLG_SPEED;
+  if (swe_calc(jd_et, ipl, flag, x, serr) < 0) 
+    return jd_et - 1;
+  xlat = x[1];
+  jd = jd_et + 1;
+  for(;;) {	// get to sign change
+    if (swe_calc(jd, ipl, flag, x, serr) < 0) 
+      return jd_et - 1;
+    if ((x[1] >= 0 && xlat < 0) || (x[1] < 0 && xlat > 0)) 
+      break;
+    jd += 1;
+  }
+  dist = x[1];
+  for(;;) {
+    jd -= dist / x[4];
+    if (swe_calc(jd, ipl, flag, x, serr) < 0) 
+      return jd_et - 1;
+    dist = x[1];
+    if (fabs(dist) < CROSS_PRECISION) {
+      *xlon = x[0];
+      *xla = x[1];
+      break;
+    }
+  } 
+  return jd;
+}
+/*************************************************
+ * compute next Moon crossing over node in UT, by finding zero latitude crossing
+ * returns juldate of the next crossing, with jd > jd_ut
+ * The returned time is universal time;
+ * Errors are indicated by returning a jd < jd_ut!
+ *************************************************/
+double CALL_CONV swe_mooncross_node_ut(double jd_ut, int flag, double *xlon, double *xla, char *serr)
+{
+  double x[6], xlat, dist;
+  double jd;
+  int ipl = SE_MOON;
+  flag |= SEFLG_SPEED;
+  if (swe_calc_ut(jd_ut, ipl, flag, x, serr) < 0) 
+    return jd_ut - 1;
+  xlat = x[1];
+  jd = jd_ut + 1;
+  for(;;) {	// get to sign change
+    if (swe_calc_ut(jd, ipl, flag, x, serr) < 0) 
+      return jd_ut - 1;
+    if ((x[1] >= 0 && xlat < 0) || (x[1] < 0 && xlat > 0)) 
+      break;
+    jd += 1;
+  }
+  dist = x[1];
+  for(;;) {
+    jd -= dist / x[4];
+    if (swe_calc_ut(jd, ipl, flag, x, serr) < 0) 
+      return jd_ut - 1;
+    dist = x[1];
+    if (fabs(dist) < CROSS_PRECISION) {
+      *xlon = x[0];
+      *xla = x[1];
+      break;
+    }
+  } 
+  return jd;
+}
+
+/*************************************************
+ * compute a planets heliocentric crossing over some longitude
+ * returns juldate of the next crossing, with jd > jd_et if dir >= 0,
+ * or the previous crossing, if dir < 0.
+ * The returned time is ephemeris time.
+ * Errors are indicated by returning ERR;
+ * This should only be used for rought house entry or exit times.
+ *************************************************/
+int32 CALL_CONV swe_helio_cross(int ipl, double x2cross, double jd_et, int iflag, int dir, double *jd_cross, char *serr)
+{
+  double x[6], xlp, dist;
+  double jd;
+  int flag = iflag | SEFLG_SPEED | SEFLG_HELCTR;
+  if (ipl == SE_SUN 
+    || ipl == SE_MOON 
+    || (ipl >= SE_MEAN_NODE && ipl <= SE_OSCU_APOG)
+    || (ipl >= SE_INTP_APOG && ipl < SE_NPLANETS)
+  ) {
+    char snam[AS_MAXCH];
+    swe_get_planet_name(ipl, snam);
+    if (serr != NULL) sprintf(serr, "swe_helio_cross: not possible for object %d = %s", ipl, snam);
+    return ERR;
+  }
+  if (swe_calc(jd_et, ipl, flag, x, serr) < 0) 
+    return ERR;
+  xlp = x[3];	
+  if (ipl == SE_CHIRON)
+    xlp = 0.01971;	// use mean speeed
+  dist = swe_degnorm(x2cross - x[0]);
+  if (dir >= 0) {
+    jd = jd_et + dist / xlp;
+  } else {
+    dist = 360.0 - dist;
+    jd = jd_et - dist / xlp;
+  }
+  for(;;) {
+    if (swe_calc(jd, ipl, flag, x, serr) < 0) 
+      return ERR;
+    dist = swe_difdeg2n(x2cross, x[0]);
+    jd += dist / x[3];
+    if (fabs(dist) < CROSS_PRECISION) break;
+  } 
+  *jd_cross = jd;
+  return OK;
+}
+
+/*************************************************
+ * compute a planets heliocentric crossing over some longitude
+ * returns juldate of the next crossing, with jd > jd_ut if dir >= 0,
+ * or the previous crossing, if dir < 0.
+ * The returned time is Universal time.
+ * Errors are indicated by returning ERR;
+ * This should only be used for rought house entry or exit times.
+ *************************************************/
+int32 CALL_CONV swe_helio_cross_ut(int ipl, double x2cross, double jd_ut, int iflag, int dir, double *jd_cross, char *serr)
+{
+  double x[6], xlp, dist;
+  double jd;
+  int flag = iflag | SEFLG_SPEED | SEFLG_HELCTR;
+  if (ipl == SE_SUN 
+    || ipl == SE_MOON 
+    || (ipl >= SE_MEAN_NODE && ipl <= SE_OSCU_APOG)
+    || (ipl >= SE_INTP_APOG && ipl < SE_NPLANETS)
+  ) {
+    char snam[AS_MAXCH];
+    swe_get_planet_name(ipl, snam);
+    if (serr != NULL) sprintf(serr, "swe_helio_cross: not possible for object %d = %s", ipl, snam);
+    return ERR;
+  }
+  if (swe_calc_ut(jd_ut, ipl, flag, x, serr) < 0) 
+    return ERR;
+  xlp = x[3];	
+  if (ipl == SE_CHIRON)
+    xlp = 0.01971;	// use mean speeed
+  dist = swe_degnorm(x2cross - x[0]);
+  if (dir >= 0) {
+    jd = jd_ut + dist / xlp;
+  } else {
+    dist = 360.0 - dist;
+    jd = jd_ut - dist / xlp;
+  }
+  for(;;) {
+    if (swe_calc_ut(jd, ipl, flag, x, serr) < 0) 
+      return ERR;
+    dist = swe_difdeg2n(x2cross, x[0]);
+    jd += dist / x[3];
+    if (fabs(dist) < CROSS_PRECISION) break;
+  } 
+  *jd_cross = jd;
+  return OK;
+}

--- a/csrc/sweph.h
+++ b/csrc/sweph.h
@@ -62,7 +62,7 @@
  * move over from swephexp.h
  */
 
-#define SE_VERSION      "2.10.01" 
+#define SE_VERSION      "2.10.02" 
 
 #define J2000           2451545.0  	/* 2000 January 1.5 */
 #define B1950           2433282.42345905  	/* 1950 January 0.923 */
@@ -313,23 +313,23 @@
 /* planetary radii in meters */
 #define NDIAM  (SE_VESTA + 1)
 static const double pla_diam[NDIAM] = {1392000000.0, /* Sun */
-                           3476300.0, /* Moon */
-                           2439000.0 * 2, /* Mercury */
-                           6052000.0 * 2, /* Venus */
-                           3397200.0 * 2, /* Mars */
-                          71398000.0 * 2, /* Jupiter */
-                          60000000.0 * 2, /* Saturn */
-                          25400000.0 * 2, /* Uranus */
-                          24300000.0 * 2, /* Neptune */
-                           2500000.0 * 2, /* Pluto */
+                           3475000.0, /* Moon */
+                           2439400.0 * 2, /* Mercury */
+                           6051800.0 * 2, /* Venus */
+                           3389500.0 * 2, /* Mars */
+                          69911000.0 * 2, /* Jupiter */
+                          58232000.0 * 2, /* Saturn */
+                          25362000.0 * 2, /* Uranus */
+                          24622000.0 * 2, /* Neptune */
+                           1188300.0 * 2, /* Pluto */
                            0, 0, 0, 0,    /* nodes and apogees */
-                           6378140.0 * 2, /* Earth */
-                                 0.0, /* Chiron */
-                                 0.0, /* Pholus */
-                            913000.0, /* Ceres */
-                            523000.0, /* Pallas */
-                            244000.0, /* Juno */
-                            501000.0, /* Vesta */
+                           6371008.4 * 2, /* Earth */
+                            271370.0, /* Chiron */
+                            290000.0, /* Pholus */
+                            939400.0, /* Ceres */
+                            545000.0, /* Pallas */
+                            246596.0, /* Juno */
+                            525400.0, /* Vesta */
                         };
 
 

--- a/csrc/swephexp.h
+++ b/csrc/swephexp.h
@@ -709,6 +709,15 @@ ext_def(int32) swe_calc_ut(double tjd_ut, int32 ipl, int32 iflag,
 
 ext_def(int32) swe_calc_pctr(double tjd, int32 ipl, int32 iplctr, int32 iflag, double *xxret, char *serr);
 
+ext_def(double) swe_solcross(double x2cross, double jd_et, int32 flag, char *serr);
+ext_def(double) swe_solcross_ut(double x2cross, double jd_ut, int32 flag, char *serr);
+ext_def(double) swe_mooncross(double x2cross, double jd_et, int32 flag, char *serr);
+ext_def(double) swe_mooncross_ut(double x2cross, double jd_ut, int32 flag, char *serr);
+ext_def(double) swe_mooncross_node(double jd_et, int32 flag, double *xlon, double *xlat, char *serr);
+ext_def(double) swe_mooncross_node_ut(double jd_ut, int32 flag, double *xlon, double *xlat, char *serr);
+ext_def(int32) swe_helio_cross(int32 ipl, double x2cross, double jd_et, int32 iflag, int32 dir, double *jd_cross, char *serr);
+ext_def(int32) swe_helio_cross_ut(int32 ipl, double x2cross, double jd_ut, int32 iflag, int32 dir, double *jd_cross, char *serr);
+
 /* fixed stars */
 ext_def( int32 ) swe_fixstar(
         char *star, double tjd, int32 iflag, 

--- a/csrc/swephexp.h
+++ b/csrc/swephexp.h
@@ -710,9 +710,13 @@ ext_def(int32) swe_calc_ut(double tjd_ut, int32 ipl, int32 iflag,
 ext_def(int32) swe_calc_pctr(double tjd, int32 ipl, int32 iplctr, int32 iflag, double *xxret, char *serr);
 
 ext_def(double) swe_solcross(double x2cross, double jd_et, int32 flag, char *serr);
+ext_def(double) swe_solcross_between(double x2cross, double jd_et_start, double jd_et_end, int32 flag, char *serr);
 ext_def(double) swe_solcross_ut(double x2cross, double jd_ut, int32 flag, char *serr);
+ext_def(double) swe_solcross_ut_between(double x2cross, double jd_ut_start, double jd_ut_end, int32 flag, char *serr);
 ext_def(double) swe_mooncross(double x2cross, double jd_et, int32 flag, char *serr);
+ext_def(double) swe_mooncross_between(double x2cross, double jd_et_start, double jd_et_end, int32 flag, char *serr);
 ext_def(double) swe_mooncross_ut(double x2cross, double jd_ut, int32 flag, char *serr);
+ext_def(double) swe_mooncross_ut_between(double x2cross, double jd_ut_start, double jd_ut_end, int32 flag, char *serr);
 ext_def(double) swe_mooncross_node(double jd_et, int32 flag, double *xlon, double *xlat, char *serr);
 ext_def(double) swe_mooncross_node_ut(double jd_ut, int32 flag, double *xlon, double *xlat, char *serr);
 ext_def(int32) swe_helio_cross(int32 ipl, double x2cross, double jd_et, int32 iflag, int32 dir, double *jd_cross, char *serr);

--- a/csrc/swephlib.c
+++ b/csrc/swephlib.c
@@ -4186,7 +4186,7 @@ void CALL_CONV swe_set_astro_models(char *samod, int32 iflag)
   double dversion;
   char s[30], *sp;
   swi_init_swed_if_start();
-  if (*samod != '\0' && isdigit(*samod)) {
+  if (*samod != '\0' && isdigit((int) *samod)) {
     set_astro_models(samod);
   } else if (*samod == '\0' || strncmp(samod, "SE", 2) == 0) {
     strncpy(s, samod, 20);
@@ -4414,21 +4414,29 @@ void CALL_CONV swe_get_astro_models(char *samod, char *sdet, int32 iflag)
     imod = pmodel[i];
     switch(i) {
       case SE_MODEL_PREC_LONGTERM:
-	if (imod == SEMOD_PREC_DEFAULT) imod = 0; break;
+	if (imod == SEMOD_PREC_DEFAULT) imod = 0;
+	break;
       case SE_MODEL_PREC_SHORTTERM:
-	if (imod == SEMOD_PREC_DEFAULT_SHORT) imod = 0; break;
+	if (imod == SEMOD_PREC_DEFAULT_SHORT) imod = 0;
+	break;
       case SE_MODEL_NUT:
-	if (imod == SEMOD_NUT_DEFAULT) imod = 0; break;
+	if (imod == SEMOD_NUT_DEFAULT) imod = 0;
+	break;
       case SE_MODEL_SIDT:
-	if (imod == SEMOD_SIDT_DEFAULT) imod = 0; break;
+	if (imod == SEMOD_SIDT_DEFAULT) imod = 0;
+	break;
       case SE_MODEL_BIAS:
-	if (imod == SEMOD_BIAS_DEFAULT) imod = 0; break;
+	if (imod == SEMOD_BIAS_DEFAULT) imod = 0;
+	break;
       case SE_MODEL_JPLHOR_MODE:
-	if (imod == SEMOD_JPLHOR_DEFAULT) imod = 0; break;
+	if (imod == SEMOD_JPLHOR_DEFAULT) imod = 0;
+	break;
       case SE_MODEL_JPLHORA_MODE:
-	if (imod == SEMOD_JPLHORA_DEFAULT) imod = 0; break;
+	if (imod == SEMOD_JPLHORA_DEFAULT) imod = 0;
+	break;
       case SE_MODEL_DELTAT:
-	if (imod == SEMOD_DELTAT_DEFAULT) imod = 0; break;
+	if (imod == SEMOD_DELTAT_DEFAULT) imod = 0;
+	break;
     }
     sprintf(samod0 + strlen(samod0), "%d,", imod);
   }

--- a/csrc/swevents.c
+++ b/csrc/swevents.c
@@ -1378,7 +1378,7 @@ static void print_item(char *s, double teph, double dpos, double delon, double d
 	sprintf(smag, "   %8.5f AU", dmag);
     }
   } else {
-    strcpy(smag, " ");
+    *smag = '\0';
   }
   if (do_motab) {
     if (yout != prev_yout && prev_yout != -999999)
@@ -1396,25 +1396,26 @@ static void print_item(char *s, double teph, double dpos, double delon, double d
       putchar('\n');
     else if (ipl > SE_VENUS && strncmp(s, "conj", 4) == 0)
       putchar('\n');
-    if (*gap != '\t') printf("%-20s ", s);
+    printf("%-20s%s", s, gap);
     if (date_gap) {
       printf("%02d%s%s%s%2d%s%s%02d:%02d:%02d",
 	     yout, gap, month_nam[mout], gap, dout, jul, gap, hour, min, sec);
     } else {
-      printf("%02d %s %2d %s %02d:%02d:%02d  ",
+      printf("%02d %s %2d %s %02d:%02d:%02d ",
 	     yout, month_nam[mout], dout, jul, hour, min, sec);
     } 
     if (show_jd)
-      printf(" jd=%.8lf ", teph);
+      printf("%sjd=%.8lf", gap, teph);
+    printf("%s", gap);
     if (is_ingr45) {
-      printf("%s%s", gap, sign_deg);
+      printf("%s", sign_deg);
       izod = (int) (dpos + 0.1);
       if (date_gap)
 	printf("%s%s", gap, znam[izod]);
       else
 	printf(" %s", znam[izod]);
     } else if (is_ingress) {
-      printf("%s%s", gap, sign_deg);
+      printf("%s", sign_deg);
       izod = (int) (dpos + 0.1);
       if (date_gap)
 	printf("%s%s", gap, znam[izod]);
@@ -1432,18 +1433,20 @@ static void print_item(char *s, double teph, double dpos, double delon, double d
       case 4:
 	strcpy(sout, " h/wane"); break;
       }
-      printf("%s%s%s%d", gap, sout, gap, izod);
+      printf("%s%s%d", sout, gap, izod);
       if (delon != HUGE) {
-	printf("%s%s", gap, dms(delon, BIT_ZODIAC|BIT_ROUND_SEC));
+	printf("%s", dms(delon, BIT_ZODIAC|BIT_ROUND_SEC));
 	delon = HUGE;
       }
     } else {
-      printf(" %s", dms(dpos, BIT_ZODIAC|BIT_ROUND_SEC));
+      printf("%s", dms(dpos, BIT_ZODIAC|BIT_ROUND_SEC));
     }
     if (delon != HUGE) {
-      printf(" %s", dms(delon, BIT_ROUND_SEC));
+      printf("%s%s", gap, dms(delon, BIT_ROUND_SEC));
     }
-    printf("%s\n", smag);  /**/
+    if (*smag)
+      printf("%s%s", gap, smag);  /**/
+    printf("\n");
   } 
 #if PRINTMOD
   else {

--- a/package.yaml
+++ b/package.yaml
@@ -50,6 +50,7 @@ library:
     - csrc/swephlib.c
     - csrc/dgravgroup.c
     - csrc/configurable_sweephe4.c
+    - csrc/interpolate.c
   include-dirs: csrc
   install-includes:
     - csrc/swedate.h
@@ -65,6 +66,7 @@ library:
     - csrc/swephlib.h
     - csrc/dgravgroup.h
     - csrc/configurable_sweephe4.h
+    - csrc/interpolate.h
 
 tests:
   swiss-ephemeris-test:

--- a/src/Foreign/Interpolate.hsc
+++ b/src/Foreign/Interpolate.hsc
@@ -119,3 +119,37 @@ foreign import ccall unsafe "interpolate.h swe_interpolate_ut"
                        -- err message
                        -> IO CInt
                        -- ^ OK/ERR
+
+foreign import ccall unsafe "interpolate.h swe_interpolate_moon_phase"
+  c_swe_interpolate_moon_phase
+    :: CDouble
+    -- ^ phase angle
+    -> CDouble
+    -- ^ JD(TT) a moment before the phase is exact
+    -> CDouble
+    -- ^ JD(TT) a moment after the phase is exact
+    -> CalcFlag
+    -- ^ iflag
+    -> Ptr CDouble
+    -- ^ moment of exactitude
+    -> CString
+    -- ^ err message
+    -> IO CInt
+    -- ^ OK/ERR
+
+foreign import ccall unsafe "interpolate.h swe_interpolate_moon_phase_ut"
+  c_swe_interpolate_moon_phase_ut
+    :: CDouble
+    -- ^ phase angle
+    -> CDouble
+    -- ^ JD(UT1) a moment before the phase is exact
+    -> CDouble
+    -- ^ JD(UT1) a moment after the phase is exact
+    -> CalcFlag
+    -- ^ iflag
+    -> Ptr CDouble
+    -- ^ moment of exactitude
+    -> CString
+    -- ^ err message
+    -> IO CInt
+    -- ^ OK/ERR

--- a/src/Foreign/Interpolate.hsc
+++ b/src/Foreign/Interpolate.hsc
@@ -83,3 +83,39 @@ foreign import ccall unsafe "interpolate.h swe_next_direction_change_ut_between"
                                          -- ^ error message
                                          -> IO CInt
                                          -- ^ OK/ERR
+
+foreign import ccall unsafe "interpolate.h swe_interpolate"
+  c_swe_interpolate :: PlanetNumber
+                    -- ^ planet crossing
+                    -> CDouble
+                    -- ^ longitude to cross
+                    -> CDouble
+                    -- ^ JD(TT) a moment before the crossing
+                    -> CDouble
+                    -- ^ JD(TT) a moment after the crossing
+                    -> CalcFlag
+                    -- iflag
+                    -> Ptr CDouble
+                    -- ^ moment of crossing
+                    -> CString
+                    -- err message
+                    -> IO CInt
+                    -- ^ OK/ERR
+
+foreign import ccall unsafe "interpolate.h swe_interpolate_ut"
+  c_swe_interpolate_ut :: PlanetNumber
+                       -- ^ planet crossing
+                       -> CDouble
+                       -- ^ longitude to cross
+                       -> CDouble
+                       -- ^ JD(UT1) a moment before the crossing
+                       -> CDouble
+                       -- ^ JD(UT1) a moment after the crossing
+                       -> CalcFlag
+                       -- iflag
+                       -> Ptr CDouble
+                       -- ^ moment of crossing
+                       -> CString
+                       -- err message
+                       -> IO CInt
+                       -- ^ OK/ERR

--- a/src/Foreign/Interpolate.hsc
+++ b/src/Foreign/Interpolate.hsc
@@ -1,0 +1,85 @@
+{-# LANGUAGE CPP, ForeignFunctionInterface #-}
+
+-- |
+-- Module: Foreign.Interpolate
+-- 
+-- Functions to find moments of exactitude; currently only an
+-- interpolation of exact moment of direction change for a given planet.
+
+module Foreign.Interpolate where
+
+import Foreign
+import Foreign.C.Types
+import Foreign.C.String
+import Foreign.SwissEphemeris
+
+#include <interpolate.h>
+
+
+foreign import ccall unsafe "interpolate.h swe_next_direction_change"
+  c_swe_next_direction_change :: CDouble
+                              -- ^ JD (TT) to start search
+                              -> PlanetNumber
+                              -- ^ planet
+                              -> CalcFlag
+                              -- ^ @iflag@ -- ephemeris flags
+                              -> Ptr CDouble
+                              -- ^ [return] JD(TT) when direction changes
+                              -> Ptr CInt
+                              -- ^ [return] <0 if new dir is retrograde
+                              -> CString
+                              -- ^ error message
+                              -> IO CInt
+                              -- ^ OK/ERR
+
+foreign import ccall unsafe "interpolate.h swe_next_direction_change_ut"
+  c_swe_next_direction_change_ut :: CDouble
+                                 -- ^ JD (UT1) to start search
+                                 -> PlanetNumber
+                                 -- ^ planet
+                                 -> CalcFlag
+                                 -- ^ @iflag@ -- ephemeris flags
+                                 -> Ptr CDouble
+                                 -- ^ [return] JD(UT1) when direction changes
+                                 -> Ptr CInt
+                                 -- ^ [return] <0 if new dir is retrograde
+                                 -> CString
+                                 -- ^ error message
+                                 -> IO CInt
+                                 -- ^ OK/ERR
+
+foreign import ccall unsafe "interpolate.h swe_next_direction_change_between"
+  c_swe_next_direction_change_between :: CDouble
+                                      -- ^ JD (TT) to start search
+                                      -> CDouble
+                                      -- ^ JD (TT) to end search
+                                      -> PlanetNumber
+                                      -- ^ planet
+                                      -> CalcFlag
+                                      -- ^ @iflag@ -- ephemeris flags
+                                      -> Ptr CDouble
+                                      -- ^ [return] JD(TT) when direction changes
+                                      -> Ptr CInt
+                                      -- ^ [return] <0 if new dir is retrograde
+                                      -> CString
+                                      -- ^ error message
+                                      -> IO CInt
+                                      -- ^ OK/ERR
+
+foreign import ccall unsafe "interpolate.h swe_next_direction_change_ut_between"
+  c_swe_next_direction_change_ut_between :: CDouble
+                                         -- ^ JD (UT1) to start search
+                                         -> CDouble
+                                         -- ^ JD (UT1) to end search
+                                         -> PlanetNumber
+                                         -- ^ planet
+                                         -> CalcFlag
+                                         -- ^ @iflag@ -- ephemeris flags
+                                         -> Ptr CDouble
+                                         -- ^ [return] JD(UT1) when direction changes
+                                         -> Ptr CInt
+                                         -- ^ [return] <0 if new dir is retrograde
+                                         -> CString
+                                         -- ^ error message
+                                         -> IO CInt
+                                         -- ^ OK/ERR

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -308,3 +308,116 @@ foreign import ccall unsafe "swephexp.h swe_pheno_ut"
                    -- ^ *serr
                    -> IO CInt
                    -- ^ retval
+
+foreign import ccall unsafe "swephexp.h swe_solcross"
+  c_swe_solcross :: CDouble
+                 -- ^ x2cross -- longitude to cross
+                 -> CDouble
+                 -- ^ JD (TT)
+                 -> CalcFlag
+                 -- ^ flag
+                 -> CString
+                 -- ^ serr
+                 -> IO CDouble
+                 -- ^ JD (time of next crossing; if in the past, we failed.)
+
+foreign import ccall unsafe "swephexp.h swe_solcross_ut"
+  c_swe_solcross_ut :: CDouble
+                    -- ^ x2cross -- longitude to cross
+                    -> CDouble
+                    -- ^ JD (UT1/UT)
+                    -> CalcFlag
+                    -- ^ flag
+                    -> CString
+                    -- ^ serr
+                    -> IO CDouble
+                    -- ^ JD (time of next crossing; if in the past, we failed.)
+
+foreign import ccall unsafe "swephexp.h swe_mooncross"
+  c_swe_mooncross :: CDouble
+                  -- ^ x2cross -- longitude to cross
+                  -> CDouble
+                  -- ^ JD (TT)
+                  -> CalcFlag
+                  -- ^ flag
+                  -> CString
+                  -- ^ serr
+                  -> IO CDouble
+                  -- ^ JD (time of next crossing; if in the past, we failed.)
+
+foreign import ccall unsafe "swephexp.h swe_mooncross_ut"
+  c_swe_mooncross_ut :: CDouble
+                     -- ^ x2cross -- longitude to cross
+                     -> CDouble
+                     -- ^ JD (UT1/UT)
+                     -> CalcFlag
+                     -- ^ flag
+                     -> CString
+                     -- ^ serr
+                     -> IO CDouble
+                     -- ^ JD (time of next crossing; if in the past, we failed.)
+
+foreign import ccall unsafe "swephexp.h swe_mooncross_node"
+  c_swe_mooncross_node :: CDouble
+                       -- ^ JD (TT)
+                       -> CalcFlag
+                       -- ^ flag
+                       -> Ptr CDouble
+                       -- ^ [return] xlon
+                       -> Ptr CDouble
+                       -- ^ [return] xlat
+                       -> CString
+                       -- ^ serr
+                       -> IO CDouble
+                       -- ^ JD (time of next crossing) 
+
+foreign import ccall unsafe "swephexp.h swe_mooncross_node_ut"
+  c_swe_mooncross_node_ut :: CDouble
+                          -- ^ JD (TT)
+                          -> CalcFlag
+                          -- ^ flag
+                          -> Ptr CDouble
+                          -- ^ [return] xlon
+                          -> Ptr CDouble
+                          -- ^ [return] xlat
+                          -> CString
+                          -- ^ serr
+                          -> IO CDouble
+                          -- ^ JD (time of next crossing) 
+
+
+foreign import ccall unsafe "swephexp.h swe_helio_cross"
+  c_swe_helio_cross :: PlanetNumber
+                    -- ^ planet
+                    -> CDouble
+                    -- ^ x2cross
+                    -> CDouble
+                    -- ^ JD (TT)
+                    -> CalcFlag
+                    -- ^ iflag
+                    -> CInt
+                    -- ^ dir (< 0 back, >0 forward)
+                    -> Ptr CDouble
+                    -- ^ JD
+                    -> CString
+                    -- ^ serr
+                    -> IO CInt
+                    -- ^ retval (OK/ERR)
+
+foreign import ccall unsafe "swephexp.h swe_helio_cross_ut"
+  c_swe_helio_cross_ut :: PlanetNumber
+                       -- ^ planet
+                       -> CDouble
+                       -- ^ x2cross
+                       -> CDouble
+                       -- ^ JD (TT)
+                       -> CalcFlag
+                       -- ^ iflag
+                       -> CInt
+                       -- ^ dir (< 0 back, >0 forward)
+                       -> Ptr CDouble
+                       -- ^ JD
+                       -> CString
+                       -- ^ serr
+                       -> IO CInt
+                       -- ^ retval (OK/ERR)

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -456,12 +456,50 @@ foreign import ccall unsafe "swephexp.h swe_sol_eclipse_when_glob"
                               -> Ptr CDouble
                               -- ^ ret[10] eclipse time highlights
                               -> CInt
-                              -- ^ BOOL: forward/backward
+                              -- ^ BOOL: search backward?
                               -> CString
                               -- ^ serr
                               -> IO CInt
-                              -- ^ retval (OK/ERR)
+                              -- ^ retval (ERR/Eclipse type)
                               
+foreign import ccall unsafe "swephexp.h swe_sol_eclipse_where"
+  c_swe_sol_eclipse_where :: CDouble
+                          -- ^ JD(UT), must be known time of maximum eclipse
+                          -> CalcFlag
+                          -- ^ iflag
+                          -> Ptr CDouble
+                          -- ^ [return] geopos
+                          -> Ptr CDouble
+                          -- ^ [return] attr
+                          -> CString
+                          -- ^ serr
+                          -> IO CInt
+                          -- ^ ret (ERR/eclipse type)
+                          
+-- | Given a search date, lat/lng/height of a geographic vantage point,
+-- return an eclipse's maximum, four contacts and other important events,
+-- and various attributes. See:
+-- [8.2.  swe_sol_eclipse_when_loc](https://www.astro.com/swisseph/swephprg.htm#_Toc78973580).
+-- NOTE(luis) only providing the C binding right now, as I have no /current/ use for all this
+-- data, and don't want to provide an opinionated Haskell equivalent until I do. 
+foreign import ccall unsafe "swephexp.h swe_sol_eclipse_when_loc"
+  c_swe_sol_eclipse_when_loc :: CDouble
+                             -- ^ JD(UT), time to start searching
+                             -> CalcFlag
+                             -- ^ iflag
+                             -> Ptr CDouble
+                             -- ^ geopos of a known locale
+                             -> Ptr CDouble
+                             -- ^ [return] tret (contacts)
+                             -> Ptr CDouble
+                             -- ^ [return] other attributes
+                             -> CInt
+                             -- ^ BOOL: search backward?
+                             -> CString
+                             -- ^ serr
+                             -> IO CInt
+                             -- ^ ret (ERR/eclipse type)
+ 
 foreign import ccall unsafe "swephexp.h swe_lun_eclipse_when"
   c_swe_lun_eclipse_when :: CDouble
                          -- ^ JD(UT)
@@ -477,3 +515,28 @@ foreign import ccall unsafe "swephexp.h swe_lun_eclipse_when"
                          -- ^ serr
                          -> IO CInt
                          -- ^ retval (OK/ERR)
+
+-- | Given a search date, lat/lng/height of a geographic vantage point,
+-- return an eclipse's maximum, four contacts and other important events,
+-- and various attributes. See:
+-- [8.9.  swe_lun_eclipse_when_loc](https://www.astro.com/swisseph/swephprg.htm#_Toc78973587).
+-- NOTE(luis) only providing the C binding right now, as I have no /current/ use for all this
+-- data, and don't want to provide an opinionated Haskell equivalent until I do. 
+foreign import ccall unsafe "swephexp.h swe_lun_eclipse_when_loc"
+  c_swe_lun_eclipse_when_loc :: CDouble
+                             -- ^ JD(UT), time to start searching
+                             -> CalcFlag
+                             -- ^ iflag
+                             -> Ptr CDouble
+                             -- ^ geopos of a known locale
+                             -> Ptr CDouble
+                             -- ^ [return] tret (contacts)
+                             -> Ptr CDouble
+                             -- ^ [return] other attributes
+                             -> CInt
+                             -- ^ BOOL: search backward?
+                             -> CString
+                             -- ^ serr
+                             -> IO CInt
+                             -- ^ ret (ERR/eclipse type)
+ 

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -280,3 +280,31 @@ foreign import ccall unsafe "swephexp.h swe_jdut1_to_utc"
                       -> Ptr CDouble
                       -- ^ sec
                       -> IO ()
+
+foreign import ccall unsafe "swephexp.h swe_pheno"
+    c_swe_pheno :: CDouble
+                -- ^ JD (TT)
+                -> PlanetNumber
+                -- ^ ipl
+                -> CalcFlag
+                -- ^ iflag
+                -> Ptr CDouble
+                -- ^ *attr
+                -> CString
+                -- ^ *serr
+                -> IO CInt
+                -- ^ retval
+
+foreign import ccall unsafe "swephexp.h swe_pheno_ut"
+    c_swe_pheno_ut :: CDouble
+                   -- ^ JD (UT)
+                   -> PlanetNumber
+                   -- ^ ipl
+                   -> CalcFlag
+                   -- ^ iflag
+                   -> Ptr CDouble
+                   -- ^ *attr
+                   -> CString
+                   -- ^ *serr
+                   -> IO CInt
+                   -- ^ retval

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -41,6 +41,9 @@ newtype CalcFlag = CalcFlag
 newtype SplitDegFlag = SplitDegFlag
   { unSplitDegFlag :: CInt } deriving (Eq, Show)
 
+newtype EclipseFlag = EclipseFlag
+  { unEclipseFlag :: CInt} deriving (Eq, Show)
+
 -- following:
 -- https://en.wikibooks.org/wiki/Haskell/FFI#Enumerations
 
@@ -91,6 +94,22 @@ newtype SplitDegFlag = SplitDegFlag
  , splitKeepSign  = SE_SPLIT_DEG_KEEP_SIGN
  , splitKeepDeg   = SE_SPLIT_DEG_KEEP_DEG
  }
+ 
+#{enum EclipseFlag, EclipseFlag
+ , eclipseCentral = SE_ECL_CENTRAL
+ , eclipseNonCentral = SE_ECL_NONCENTRAL
+ , eclipseTotal = SE_ECL_TOTAL
+ , eclipseAnnular = SE_ECL_ANNULAR
+ , eclipsePartial = SE_ECL_PARTIAL
+ , eclipseAnnularTotal = SE_ECL_ANNULAR_TOTAL
+ , eclipseHybrid = SE_ECL_HYBRID
+ , eclipsePenumbral = SE_ECL_PENUMBRAL
+ , eclipseSolar = SE_ECL_ALLTYPES_SOLAR
+ , eclipseLunar = SE_ECL_ALLTYPES_LUNAR
+}
+
+anyEclipse :: EclipseFlag
+anyEclipse = EclipseFlag 0
 
 foreign import ccall unsafe "swephexp.h swe_set_ephe_path"
     c_swe_set_ephe_path :: CString -> IO ()
@@ -421,3 +440,40 @@ foreign import ccall unsafe "swephexp.h swe_helio_cross_ut"
                        -- ^ serr
                        -> IO CInt
                        -- ^ retval (OK/ERR)
+
+
+------------------------------------------------
+-- ECLIPSES
+------------------------------------------------
+
+foreign import ccall unsafe "swephexp.h swe_sol_eclipse_when_glob"
+  c_swe_sol_eclipse_when_glob :: CDouble
+                              -- ^ JD(UT)
+                              -> CalcFlag
+                              -- ^ iflag
+                              -> EclipseFlag
+                              -- ^ ifltype
+                              -> Ptr CDouble
+                              -- ^ ret[10] eclipse time highlights
+                              -> CInt
+                              -- ^ BOOL: forward/backward
+                              -> CString
+                              -- ^ serr
+                              -> IO CInt
+                              -- ^ retval (OK/ERR)
+                              
+foreign import ccall unsafe "swephexp.h swe_lun_eclipse_when"
+  c_swe_lun_eclipse_when :: CDouble
+                         -- ^ JD(UT)
+                         -> CalcFlag
+                         -- ^ iflag
+                         -> EclipseFlag
+                         -- ^ ifltype
+                         -> Ptr CDouble
+                         -- ^ ret[10] eclipse time highlights
+                         -> CInt
+                         -- ^ BOOL: forward/backward
+                         -> CString
+                         -- ^ serr
+                         -> IO CInt
+                         -- ^ retval (OK/ERR)

--- a/src/Foreign/SwissEphemeris.hsc
+++ b/src/Foreign/SwissEphemeris.hsc
@@ -340,6 +340,21 @@ foreign import ccall unsafe "swephexp.h swe_solcross"
                  -> IO CDouble
                  -- ^ JD (time of next crossing; if in the past, we failed.)
 
+foreign import ccall unsafe "swephexp.h swe_solcross_between"
+  c_swe_solcross_between :: CDouble
+                         -- ^ x2cross -- longitude to cross
+                         -> CDouble
+                         -- ^ JD (TT) -- start
+                         -> CDouble
+                         -- ^ JD (TT) -- end
+                         -> CalcFlag
+                         -- ^ flag
+                         -> CString
+                         -- ^ serr
+                         -> IO CDouble
+                         -- ^ JD (time of next crossing; if in the past, we failed.)
+
+
 foreign import ccall unsafe "swephexp.h swe_solcross_ut"
   c_swe_solcross_ut :: CDouble
                     -- ^ x2cross -- longitude to cross
@@ -351,6 +366,21 @@ foreign import ccall unsafe "swephexp.h swe_solcross_ut"
                     -- ^ serr
                     -> IO CDouble
                     -- ^ JD (time of next crossing; if in the past, we failed.)
+
+foreign import ccall unsafe "swephexp.h swe_solcross_ut_between"
+  c_swe_solcross_ut_between :: CDouble
+                            -- ^ x2cross -- longitude to cross
+                            -> CDouble
+                            -- ^ JD (UT1/UT) -- start
+                            -> CDouble
+                            -- ^ JD (UT1/UT) -- end
+                            -> CalcFlag
+                            -- ^ flag
+                            -> CString
+                            -- ^ serr
+                            -> IO CDouble
+                            -- ^ JD (time of next crossing; if in the past, we failed.)
+
 
 foreign import ccall unsafe "swephexp.h swe_mooncross"
   c_swe_mooncross :: CDouble
@@ -364,6 +394,21 @@ foreign import ccall unsafe "swephexp.h swe_mooncross"
                   -> IO CDouble
                   -- ^ JD (time of next crossing; if in the past, we failed.)
 
+foreign import ccall unsafe "swephexp.h swe_mooncross_between"
+  c_swe_mooncross_between :: CDouble
+                          -- ^ x2cross -- longitude to cross
+                          -> CDouble
+                          -- ^ JD (TT) -- start
+                          -> CDouble
+                          -- ^ JD (TT) -- end
+                          -> CalcFlag
+                          -- ^ flag
+                          -> CString
+                          -- ^ serr
+                          -> IO CDouble
+                          -- ^ JD (time of next crossing; if in the past, we failed.)
+
+
 foreign import ccall unsafe "swephexp.h swe_mooncross_ut"
   c_swe_mooncross_ut :: CDouble
                      -- ^ x2cross -- longitude to cross
@@ -375,6 +420,21 @@ foreign import ccall unsafe "swephexp.h swe_mooncross_ut"
                      -- ^ serr
                      -> IO CDouble
                      -- ^ JD (time of next crossing; if in the past, we failed.)
+
+foreign import ccall unsafe "swephexp.h swe_mooncross_ut_between"
+  c_swe_mooncross_ut_between :: CDouble
+                             -- ^ x2cross -- longitude to cross
+                             -> CDouble
+                             -- ^ JD (UT1/UT) -- start
+                             -> CDouble
+                             -- ^ JD (UT1/UT) -- end
+                             -> CalcFlag
+                             -- ^ flag
+                             -> CString
+                             -- ^ serr
+                             -> IO CDouble
+                             -- ^ JD (time of next crossing; if in the past, we failed.)
+
 
 foreign import ccall unsafe "swephexp.h swe_mooncross_node"
   c_swe_mooncross_node :: CDouble

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -370,7 +370,6 @@ planetaryPhenomenonRaw :: SingTSI ts =>
 planetaryPhenomenonRaw = planetaryPhenomenonRaw' singTS
 
 planetaryPhenomenonRaw' ::
-  -- | witness to the time standard we're using:
   SingTimeStandard ts ->
   JulianDay ts ->
   PlanetNumber ->

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -693,7 +693,7 @@ nextSolarEclipseRaw iflag ifltype backward jd =
         attrs <- peekArray 10 ret
         case eclipseFlagToTypeSolar (EclipseFlag eclType) of
           Nothing -> 
-            pure . Left $ "Unknown Solar Eclipse type: " <> show eclType
+            pure . Left $ "Unknown Solar Eclipse type: " ++ show eclType
           Just set -> 
             pure . Right $ (set, map realToFrac attrs)
 
@@ -718,7 +718,7 @@ nextSolarEclipseLocationRaw iflag jd =
            attrs <- peekArray 20 attr
            case eclipseFlagToTypeSolar (EclipseFlag eclType) of
              Nothing ->
-               pure . Left $ "Unknown Solar Eclipse type: " <> show eclType
+               pure . Left $ "Unknown Solar Eclipse type: " ++ show eclType
              Just set ->
                pure . Right $ (set, map realToFrac geo, map realToFrac attrs)
 
@@ -849,7 +849,7 @@ nextLunarEclipseRaw iflag ifltype backward jd =
         attrs <- peekArray 10 ret
         case eclipseFlagToTypeLunar (EclipseFlag eclType) of
           Nothing ->
-            pure . Left $ "Unknown Lunar Eclipse type: " <> show eclType
+            pure . Left $ "Unknown Lunar Eclipse type: " ++ show eclType
           Just set ->
             pure . Right $ (set, map realToFrac attrs)
 

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -37,7 +37,7 @@ module SwissEphemeris
     EquatorialPosition (..),
     GeographicPosition (..),
     HousePosition (..),
-    -- * Information about the ecliptic at a point in time.
+    -- * Information about the ecliptic at a point in time
     ObliquityInformation (..),
     Angles (..),
     CuspsCalculation (..),
@@ -66,7 +66,7 @@ module SwissEphemeris
     -- * Utilities for sidereal information
     calculateHousePosition,
     calculateHousePositionSimple,
-    -- * Utilities for display/splitting:
+    -- * Utilities for display/splitting
     defaultSplitDegreesOptions,
     splitDegrees,
     splitDegreesZodiac,
@@ -393,6 +393,7 @@ splitDegrees' options deg =
 -- PLANETARY PHENOMENA
 -------------------------------------------------------------------------------
 
+-- | Unprocessed vector of data of note for a planetary phenomenon (see 'planetaryPhenomenon')
 planetaryPhenomenonRaw :: SingTSI ts =>
   JulianDay ts ->
   PlanetNumber ->
@@ -770,6 +771,7 @@ for subsequent calculations.
 
 -}
 
+-- | Various moments of note for a solar eclipse. 
 data SolarEclipseInformation = SolarEclipseInformation
   { solarEclipseType :: SolarEclipseType
   , solarEclipseMax :: JulianDayUT1
@@ -928,6 +930,7 @@ nextSolarEclipseWhen =
     onlyMax _ = Left "insufficient eclipse data"
     
 
+-- | Various moments of note for a lunar eclipse. 
 data LunarEclipseInformation = LunarEclipseInformation
   { lunarEclipseType :: LunarEclipseType 
   , lunarEclipseMax :: JulianDayUT1
@@ -1145,6 +1148,18 @@ nextDirectionChangeOpt' sing iflag planet jdStart =
 
 -------------------------------------------------------------------------------
 
+-- | Given a @Planet@, a longitude it crosses, and a start and end
+-- @JulianDay@s, find the exact moment the planet crosses the given longitude,
+-- from a geocentric perspective (retrogrades are taken into account).
+-- 
+-- _NOTE_: works best when it is known beforehand that the planet crosses
+-- the longitude in the given interval, and when the interval is short (e.g. 24 hours): 
+-- if the interval is too long the maximum number of iterations to approximate
+-- the moment of exactitude may be exceeded. Additionally, if the planet changes
+-- direction in the interval and crosses the longitude more than once, only one
+-- of the crossings will be found (not necessarily the first one.) You may
+-- use 'nextDirectionChange' or 'directionChangeBetween' to subdivide the interval 
+-- into sub-intervals that contain one crossing each.
 crossingBetween
   :: SingTSI ts
   => Planet

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -31,6 +31,7 @@ module SwissEphemeris
     NakshatraName (..),
     EventSearchDirection(..),
     PlanetMotion(..),
+    LunarPhase(..),
     -- * Coordinate/position systems
     EclipticPosition (..),
     EquatorialPosition (..),

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -31,7 +31,7 @@ module SwissEphemeris
     NakshatraName (..),
     EventSearchDirection(..),
     PlanetMotion(..),
-    LunarPhase(..),
+    LunarPhaseName(..),
     -- * Coordinate/position systems
     EclipticPosition (..),
     EquatorialPosition (..),

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -1198,10 +1198,10 @@ crossingBetweenOpt' sing iflag planet lng2Cross jdStart jdEnd =
 
 
 -- | Given start and end moments between which the moon is known to reach a
--- given 'LunarPhase', determine the moment of exactitude.
+-- given 'LunarPhaseName', determine the moment of exactitude.
 moonPhaseExactAt
   :: SingTSI ts
-  => LunarPhase
+  => LunarPhaseName
   -> JulianDay ts
   -> JulianDay ts
   -> IO (Either String (JulianDay ts))
@@ -1211,7 +1211,7 @@ moonPhaseExactAt =
 moonPhaseExactOpt 
   :: SingTSI ts
   => CalcFlag
-  -> LunarPhase
+  -> LunarPhaseName
   -> JulianDay ts 
   -> JulianDay ts 
   -> IO (Either String (JulianDay ts))
@@ -1221,7 +1221,7 @@ moonPhaseExactOpt =
 moonPhaseExactOpt' 
   :: SingTimeStandard ts 
   -> CalcFlag 
-  -> LunarPhase 
+  -> LunarPhaseName 
   -> JulianDay ts 
   -> JulianDay ts 
   -> IO (Either String (JulianDay ts))

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -634,28 +634,18 @@ heliocentricCrossing =
 -------------------------------------------------------------------------------
 -- ECLIPSES
 -------------------------------------------------------------------------------
--- | Important times around an eclipse
-{-
-tret[0]   time of maximum eclipse
 
-tret[1]   time, when eclipse takes place at local apparent noon
+{- NOTE(luis)
 
-tret[2]   time of eclipse begin
+We currently only have functions to determine when an eclipse is visible from /anywhere/,
+but Swiss Ephemeris is also capable of determine /where/ a solar eclipse is visible from,
+see the `swe_sol_eclipse_where` function, and the example for more a involved eclipse
+calculation routine in [8.1.  Example of a typical eclipse calculation](https://www.astro.com/swisseph/swephprg.htm#_Toc78973579)
 
-tret[3]   time of eclipse end
+What we learn from there is that the time when it's maximal is the most important datum.
 
-tret[4]   time of totality begin
-
-tret[5]   time of totality end
-
-tret[6]   time of center line begin
-
-tret[7]   time of center line end
-
-tret[8]   time when annular-total eclipse becomes total, not implemented so far
-
-tret[9]   time when annular-total eclipse becomes annular again, not implemented so far
 -}
+
 data SolarEclipseInformation = SolarEclipseInformation
   { solarEclipseType :: SolarEclipseType
   , solarEclipseMax :: JulianDayUT1
@@ -742,25 +732,6 @@ nextSolarEclipseSimple =
           h
     mkSolarEcl _ = Left "insufficient eclipse data"
 
-{-
-tret[0]   time of maximum eclipse
-
-tret[1]  
-
-tret[2]   time of partial phase begin (indices consistent with solar eclipses)
-
-tret[3]   time of partial phase end
-
-tret[4]   time of totality begin
-
-tret[5]   time of totality end
-
-tret[6]   time of penumbral phase begin
-
-tret[7]   time of penumbral phase end
-
-
--}
 data LunarEclipseInformation = LunarEclipseInformation
   { lunarLunarEclipseType :: LunarEclipseType 
   , lunarEclipseMax :: JulianDayUT1

--- a/src/SwissEphemeris.hs
+++ b/src/SwissEphemeris.hs
@@ -39,6 +39,9 @@ module SwissEphemeris
     Angles (..),
     CuspsCalculation (..),
     LongitudeComponents (..),
+    -- * Information about an Eclipse
+    SolarEclipseInformation(..),
+    LunarEclipseInformation(..),
     -- * Management of data files
     setEphemeridesPath,
     setNoEphemeridesPath,
@@ -733,7 +736,7 @@ nextSolarEclipseSimple =
     mkSolarEcl _ = Left "insufficient eclipse data"
 
 data LunarEclipseInformation = LunarEclipseInformation
-  { lunarLunarEclipseType :: LunarEclipseType 
+  { lunarEclipseType :: LunarEclipseType 
   , lunarEclipseMax :: JulianDayUT1
   , lunarEclipsePartialPhaseBegin :: JulianDayUT1
   , lunarEclipsePartialPhaseEnd :: JulianDayUT1

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -179,7 +179,7 @@ data PlanetMotion
   | DirectMotion
   deriving (Eq, Show)
   
-data LunarPhase
+data LunarPhaseName
   = NewMoon
   | WaxingCrescent
   | FirstQuarter
@@ -460,7 +460,7 @@ ephemerisOptionToFlag UseSwissEphemeris   = useSwissEph
 ephemerisOptionToFlag UseJPLEphemeris     = useJplEph
 ephemerisOptionToFlag UseMoshierEphemeris = useMoshierEph
 
-moonPhaseToAngle :: LunarPhase ->  Double
+moonPhaseToAngle :: LunarPhaseName ->  Double
 moonPhaseToAngle = \case   
   NewMoon -> 0
   WaxingCrescent -> 45

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -178,6 +178,17 @@ data PlanetMotion
   = RetrogradeMotion
   | DirectMotion
   deriving (Eq, Show)
+  
+data LunarPhase
+  = NewMoon
+  | WaxingCrescent
+  | FirstQuarter
+  | WaxingGibbous
+  | FullMoon
+  | WaningGibbous
+  | LastQuarter
+  | WaningCrescent
+  deriving (Eq, Show, Ord)
 
 -- | The cusp of a given "house" or "sector". It is an ecliptic longitude.
 -- see:
@@ -448,3 +459,14 @@ ephemerisOptionToFlag :: EphemerisOption -> EpheFlag
 ephemerisOptionToFlag UseSwissEphemeris   = useSwissEph
 ephemerisOptionToFlag UseJPLEphemeris     = useJplEph
 ephemerisOptionToFlag UseMoshierEphemeris = useMoshierEph
+
+moonPhaseToAngle :: LunarPhase ->  Double
+moonPhaseToAngle = \case   
+  NewMoon -> 0
+  WaxingCrescent -> 45
+  FirstQuarter -> 90
+  WaxingGibbous -> 135
+  FullMoon -> 180
+  WaningGibbous -> 225
+  LastQuarter -> 270
+  WaningCrescent -> 315

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -174,6 +174,11 @@ data LunarEclipseType
   | PartialLunarEclipse
   deriving (Eq, Show)
 
+data PlanetMotion
+  = RetrogradeMotion
+  | DirectMotion
+  deriving (Eq, Show)
+
 -- | The cusp of a given "house" or "sector". It is an ecliptic longitude.
 -- see:
 -- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847888 14.1 House cusp calculation>

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -161,6 +161,7 @@ data EventSearchDirection
   | SearchForward
   deriving (Eq, Show)
 
+-- | All possible types of solar eclipses.
 data SolarEclipseType
   = TotalSolarEclipse
   | AnnularEclipse
@@ -168,17 +169,20 @@ data SolarEclipseType
   | PartialSolarEclipse
   deriving (Eq, Show)
 
+-- | All possible types of lunar eclipses.
 data LunarEclipseType
   = TotalLunarEclipse
   | PenumbralEclipse
   | PartialLunarEclipse
   deriving (Eq, Show)
 
+-- | Apparent motion of a planet, from a geocentric observation.
 data PlanetMotion
   = RetrogradeMotion
   | DirectMotion
   deriving (Eq, Show)
   
+-- | Traditional western moon phases.
 data LunarPhaseName
   = NewMoon
   | WaxingCrescent

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -249,6 +249,15 @@ data LongitudeComponents = LongitudeComponents
   }
   deriving (Show, Eq, Generic)
 
+-- | A Planet's "phenomena" record
+data PlanetPhenomenon = PlanetPhenomenon
+  { planetPhaseAngle :: Double
+  , planetPhase      :: Double
+  , planetElongation :: Double
+  , planetApparentDiameter :: Double
+  , planetApparentMagnitude :: Double
+  } deriving (Eq, Show)
+
 -- folders for bitwise flags, and some opinionated defaults.
 
 mkCalculationOptions :: [CalcFlag] -> CalcFlag

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -154,7 +154,9 @@ data EphemerisOption
   | UseMoshierEphemeris
   deriving (Eq, Show)
 
-data CrossingSearchDirection
+-- | When looking for eclipses, occulations or crossings, determine
+-- the temporal direction to take from the provided start time.
+data EventSearchDirection
   = SearchBackward
   | SearchForward
   deriving (Eq, Show)
@@ -323,20 +325,20 @@ lunarEclipseTypeToFlag =
 -- NOTE(luis) apart from the types of eclipses here, a solar eclipse
 -- can also be central or noncentral, and there's a notion of hybrid;
 -- see: https://github.com/aloistr/swisseph/blob/bc59eb7ab0c3480086132ae652c6f32924f25589/swetest.c#L3348
-eclipseFlagToTypeSolar :: EclipseFlag -> SolarEclipseType
+eclipseFlagToTypeSolar :: EclipseFlag -> Maybe SolarEclipseType
 eclipseFlagToTypeSolar f
-    | f `match` eclipseTotal = TotalSolarEclipse
-    | f `match` eclipseAnnular = AnnularEclipse
-    | f `match` eclipsePartial = PartialSolarEclipse
-    | f `match` eclipseAnnularTotal = AnnularTotalEclipse
-    | otherwise = undefined
+    | f `match` eclipseTotal = Just TotalSolarEclipse
+    | f `match` eclipseAnnular = Just AnnularEclipse
+    | f `match` eclipsePartial = Just PartialSolarEclipse
+    | f `match` eclipseAnnularTotal = Just AnnularTotalEclipse
+    | otherwise = Nothing
 
-eclipseFlagToTypeLunar :: EclipseFlag -> LunarEclipseType
+eclipseFlagToTypeLunar :: EclipseFlag -> Maybe LunarEclipseType
 eclipseFlagToTypeLunar f
-    | f `match` eclipseTotal = TotalLunarEclipse
-    | f `match` eclipsePartial = PartialLunarEclipse
-    | f `match` eclipsePenumbral = PenumbralEclipse 
-    | otherwise = undefined
+    | f `match` eclipseTotal = Just TotalLunarEclipse
+    | f `match` eclipsePartial = Just PartialLunarEclipse
+    | f `match` eclipsePenumbral = Just PenumbralEclipse 
+    | otherwise = Nothing
 
 -- | Equivalent to @flag & FLAG_VALUE@ in C.
 match :: EclipseFlag -> EclipseFlag -> Bool

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -153,6 +153,11 @@ data EphemerisOption
   | UseMoshierEphemeris
   deriving (Eq, Show)
 
+data CrossingSearchDirection
+  = SearchBackward
+  | SearchForward
+  deriving (Eq, Show)
+
 -- | The cusp of a given "house" or "sector". It is an ecliptic longitude.
 -- see:
 -- <https://www.astro.com/swisseph/swephprg.htm#_Toc49847888 14.1 House cusp calculation>

--- a/src/SwissEphemeris/Precalculated.hs
+++ b/src/SwissEphemeris/Precalculated.hs
@@ -99,7 +99,7 @@ import Foreign.SweEphe4
   )
 import GHC.Generics (Generic)
 import SwissEphemeris.Internal
-  ( 
+  (
     Planet
       ( Chiron,
         Jupiter,
@@ -116,7 +116,7 @@ import SwissEphemeris.Internal
         Uranus,
         Venus
       ),
-    allocaErrorMessage,
+    allocaErrorMessage, HasEclipticLongitude(..)
   )
 import SwissEphemeris.Time
 
@@ -208,6 +208,9 @@ data EphemerisPosition a = EphemerisPosition
     -- ^ ecliptic speed in @a@ units.
   }
   deriving (Eq, Show, Generic)
+
+instance (Real a, Eq a) => HasEclipticLongitude (EphemerisPosition a) where
+  getEclipticLongitude = realToFrac . epheLongitude
 
 -- | The positions of all planets for a given time,
 -- plus ecliptic and nutation.

--- a/src/SwissEphemeris/Time.hs
+++ b/src/SwissEphemeris/Time.hs
@@ -194,7 +194,7 @@ newtype JulianDay (s :: TimeStandard) = MkJulianDay {
                                           -- 'JulianDay': you'll have to obtain it
                                           -- through the various temporal conversion functions.
                                           getJulianDay :: Double}
-  deriving (Eq, Show, Enum)
+  deriving (Eq, Show, Enum, Ord)
 
  
 -- Aliases for those who dislike datakinds

--- a/src/SwissEphemeris/Time.hs
+++ b/src/SwissEphemeris/Time.hs
@@ -39,6 +39,7 @@ module SwissEphemeris.Time
     getConversionResult,
 
     -- * Pure utility functions
+    mkJulianDay,
     coerceUT,
     julianNoon,
     julianMidnight,
@@ -196,7 +197,6 @@ newtype JulianDay (s :: TimeStandard) = MkJulianDay {
   deriving (Eq, Show, Enum)
 
  
-
 -- Aliases for those who dislike datakinds
 
 -- | A terrestrial time as a Julian Day
@@ -261,6 +261,16 @@ instance FromJulianDay 'TT UTCTime where
 -------------------------------------------------------------------------------
 -- UTILS
 -------------------------------------------------------------------------------
+
+-- | Constructor with chaperone: you have to provide a witness to a time standard
+-- to produce a 'JulianDay' directly from a 'Double'. This is mostly
+-- intended for internal use, if you find yourself using this function,
+-- you're probably producing an unreliable value: consider using the
+-- 'ToJulianDay' instance of a reliable temporal type
+-- (like 'UTCTime',) before reaching for this function.
+mkJulianDay :: SingTimeStandard ts -> Double -> JulianDay ts
+mkJulianDay _ = MkJulianDay
+
 
 -- | Coerce a value obtained directly from UTC (without
 -- consulting historical data) into a UT1 Julian Day.

--- a/swiss-ephemeris.cabal
+++ b/swiss-ephemeris.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 90daa5f2efc4359cc6aca3a861f598ff28794b3a4f4354dd22bdf096dfc405c0
+-- hash: 1f78f55bc113fd41d97119660086ed24ad498a24fc93d13d8e09a0449e0e3e60
 
 name:           swiss-ephemeris
 version:        1.4.0.0
@@ -32,6 +32,7 @@ source-repository head
 
 library
   exposed-modules:
+      Foreign.Interpolate
       Foreign.SweEphe4
       Foreign.SwissEphemeris
       Foreign.SwissEphemerisExtras
@@ -61,6 +62,7 @@ library
       csrc/swephlib.h
       csrc/dgravgroup.h
       csrc/configurable_sweephe4.h
+      csrc/interpolate.h
   c-sources:
       csrc/swecl.c
       csrc/swedate.c
@@ -75,6 +77,7 @@ library
       csrc/swephlib.c
       csrc/dgravgroup.c
       csrc/configurable_sweephe4.c
+      csrc/interpolate.c
   build-depends:
       base >=4.10 && <4.16
     , time >=1.9 && <1.13

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -341,21 +341,38 @@ spec = do
         describe "bracketed moon phase exactitude" $ do
           it "finds all moments of exactitude for September 2021 (UTC)" $ do
             let _newMoon@(nmA, nmB) = (mkJulian 2021 9 7 0, mkJulian 2021 9 8 0)
+                _waxingCrescent@(wcA, wcB) = (mkJulian 2021 9 10 0, mkJulian 2021 9 11 0)
                 _firstQuarter@(fqA, fqB) = (mkJulian 2021 9 13 0, mkJulian 2021 9 14 0)
+                _waxingGibbous@(wgA, wgB) = (mkJulian 2021 9 17 0, mkJulian 2021 9 18 0)
                 _fullMoon@(fmA, fmB) = (mkJulian 2021 9 20 0, mkJulian 2021 9 21 0)
+                _waningGibbous@(gA, gB) = (mkJulian 2021 9 24 0, mkJulian 2021 9 25 0)
                 _lastQuarter@(lqA, lqB) = (mkJulian 2021 9 29 0, mkJulian 2021 9 30 0)
+                _waningCrescent@(cA, cB) = (mkJulian 2021 10 2 0, mkJulian 2021 10 3 0)
             Right exactNewMoon <- moonPhaseExactAt NewMoon nmA nmB
+            Right exactWaxingCrescent <- moonPhaseExactAt WaxingCrescent wcA wcB
             Right exactFirstQuarter <- moonPhaseExactAt FirstQuarter fqA fqB
+            Right exactWaxingGibbous <- moonPhaseExactAt WaxingGibbous wgA wgB
             Right exactFullMoon <- moonPhaseExactAt FullMoon fmA fmB
+            Right exactWaningGibbous <- moonPhaseExactAt WaningGibbous gA gB
             Right exactLastQuarter <- moonPhaseExactAt LastQuarter lqA lqB
+            Right exactWaningCrescent <- moonPhaseExactAt WaningCrescent cA cB
+            -- cf: https://ssd.jpl.nasa.gov/tools/jdc/#/jd
             -- 2021-09-07 00:51:46 UTC
             getJulianDay exactNewMoon `shouldBe` 2459464.5359518672
+            -- 2021-09-10 11:03:31 UTC
+            getJulianDay exactWaxingCrescent `shouldBe` 2459467.9607786587
             -- 2021-09-13 20:39:22 UTC
             getJulianDay exactFirstQuarter `shouldBe` 2459471.3606688627
+            -- 2021-09-17 08:18:20 UTC
+            getJulianDay exactWaxingGibbous `shouldBe` 2459474.8460611873
             -- 2021-09-20 23:54:42 UTC
             getJulianDay exactFullMoon `shouldBe` 2459478.496323667
+            -- 2021-09-24 22:32:33 UTC
+            getJulianDay exactWaningGibbous `shouldBe` 2459482.4392759944
             -- 2021-09-29 01:57:09 UTC
             getJulianDay exactLastQuarter `shouldBe` 2459486.5813509836
+            -- 2021-10-02 23:35:14 UTC
+            getJulianDay exactWaningCrescent `shouldBe` 2459490.482804646
 
 
 

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -293,6 +293,34 @@ spec = do
             -- perspective than from a geocentric perspective.
             julianNoon crossingJD `shouldBe` julianNoon expectedCrossing
 
+      describe "changes of direction" $ do
+        describe "nextDirectionChange" $
+          it "calculates the moment of direction change of a planet after a date" $ do
+            let startTime = mkJulian 2021 7 14 0.0
+                -- 2021-Jul-15 16:41:02.9 UTC
+                expectedCrossing = 2459411.1951724007
+                expectedMotion = RetrogradeMotion
+            Right (crossingJD, motion) <- nextDirectionChange Chiron startTime
+            getJulianDay crossingJD `shouldBe` expectedCrossing
+            motion `shouldBe` expectedMotion
+        describe "directionChangeBetween" $ do
+          it "calculates the moment of direction change if it happens in the interval" $ do
+            let startTime = mkJulian 2021 7 15 0.0
+                endTime   = mkJulian 2021 7 16 0.0
+                -- 2021-Jul-15 16:41:02.9 UTC
+                expectedCrossing = 2459411.1951724007
+                expectedMotion = RetrogradeMotion
+            Right (crossingJD, motion) <- directionChangeBetween Chiron startTime endTime
+            getJulianDay crossingJD `shouldBe` expectedCrossing
+            motion `shouldBe` expectedMotion
+
+          it "fails to calculate direction change if outside of the interval" $ do
+            let startTime = mkJulian 2021 7 14 0.0
+                endTime   = mkJulian 2021 7 15 0.0
+            Left msg <- directionChangeBetween Chiron startTime endTime
+            msg `shouldBe` "swe_next_direction_change: no change within 1.000000 days"
+
+
 {- For reference, here's an official test output from swetest.c as retrieved from the swetest page:
 https://www.astro.com/cgi/swetest.cgi?b=6.1.1989&n=1&s=1&p=p&e=-eswe&f=PlbRS&arg=
 

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -338,6 +338,25 @@ spec = do
             Left msg <- crossingBetween Moon cross jd1 jd2
             msg `shouldBe` "swe_interpolate: not bracketed: 2459450.500802 - 2459451.500802"
 
+        describe "bracketed moon phase exactitude" $ do
+          it "finds all moments of exactitude for September 2021 (UTC)" $ do
+            let _newMoon@(nmA, nmB) = (mkJulian 2021 9 7 0, mkJulian 2021 9 8 0)
+                _firstQuarter@(fqA, fqB) = (mkJulian 2021 9 13 0, mkJulian 2021 9 14 0)
+                _fullMoon@(fmA, fmB) = (mkJulian 2021 9 20 0, mkJulian 2021 9 21 0)
+                _lastQuarter@(lqA, lqB) = (mkJulian 2021 9 29 0, mkJulian 2021 9 30 0)
+            Right exactNewMoon <- moonPhaseExactAt NewMoon nmA nmB
+            Right exactFirstQuarter <- moonPhaseExactAt FirstQuarter fqA fqB
+            Right exactFullMoon <- moonPhaseExactAt FullMoon fmA fmB
+            Right exactLastQuarter <- moonPhaseExactAt LastQuarter lqA lqB
+            -- 2021-09-07 00:51:46 UTC
+            getJulianDay exactNewMoon `shouldBe` 2459464.5359518672
+            -- 2021-09-13 20:39:22 UTC
+            getJulianDay exactFirstQuarter `shouldBe` 2459471.3606688627
+            -- 2021-09-20 23:54:42 UTC
+            getJulianDay exactFullMoon `shouldBe` 2459478.496323667
+            -- 2021-09-29 01:57:09 UTC
+            getJulianDay exactLastQuarter `shouldBe` 2459486.5813509836
+
 
 
 

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -301,8 +301,8 @@ compareCalculations _ _ = expectationFailure "Unable to calculate"
 -- | As noted in the readme, the test ephemeris only covers from
 -- 1800-Jan-01 AD to 2399-Dec-31
 -- the Moshier ephemeris should cover a wider range of years, but
--- they cannot compute Chiron. We're choosing a range for which
--- we have Ephemeris for chiron.
+-- they cannot compute Chiron in the general case. 
+-- We're choosing a range for which we have continuous Ephemeris for chiron.
 -- These numbers were calculated with:
 -- https://ssd.jpl.nasa.gov/tc.cgi
 -- read more in the manual:
@@ -313,11 +313,23 @@ minT = minTestEpheT
 maxT :: UTCTime
 maxT = maxTestEpheT
 
+-- see:
+-- https://github.com/aloistr/swisseph/blob/7a9a56f858f8db5128c1e5c0bf1c3bde760a0cb3/sweph.h#L207-L208
+-- and:
+-- https://github.com/aloistr/swisseph/blob/40a0baa743a7c654f0ae3331c5d9170ca1da6a6a/sweph.c#L1079
+-- It seems that even though we don't have /data/ for Chiron beyond
+-- `minT` and `maxT` above, some far out dates are still interpolated
+-- just fine; so we work with the absolute limits of the library
+-- for the negative case, instead.
+minChironEphe, maxChironEphe :: UTCTime 
+minChironEphe = mkUTC "0675-01-01T00:00:00Z"
+maxChironEphe = mkUTC "4650-01-01T00:00:00Z"
+
 genJulian :: Gen JulianDayUT1
 genJulian = genJulianInRange minT maxT
 
 genBadJulian :: Gen JulianDayUT1
-genBadJulian = oneof [genJulianBefore minT, genJulianAfter maxT]
+genBadJulian = oneof [genJulianBefore minChironEphe, genJulianAfter maxChironEphe]
 
 genHouseSystem :: Gen HouseSystem
 genHouseSystem = elements [Placidus, Koch, Porphyrius, Regiomontanus, Campanus, Equal, WholeSign]

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -243,6 +243,21 @@ spec = do
             Right crossingJD <- sunCrossing 180.0 startTime
             julianNoon crossingJD `shouldBe` julianNoon libraSeasonStart
 
+        describe "sunCrossingBetween" $ do 
+          it "calculates the geocentric solar crossing over a given longitude in an interval" $ do
+            let libraSeasonStart = mkJulian 2021 9 23 0
+                startTime = mkJulian 2021 8 9 0.0
+                endTime   = mkJulian 2021 9 24 0.0
+            Right crossingJD <- sunCrossingBetween 180.0 startTime endTime
+            julianNoon crossingJD `shouldBe` julianNoon libraSeasonStart
+   
+          it "knows when to give up calculating the geocentric solar crossing over a given longitude in an interval" $ do
+            let startTime = mkJulian 2021 8 9 0.0
+                endTime   = mkJulian 2021 9 22 0.0
+            e <- sunCrossingBetween 180.0 startTime endTime
+            e `shouldSatisfy` isLeft
+            --e `shouldBe` "No crossing found in the specified interval"
+
         describe "moonCrossing" $
           it "calculates the geocentric lunar crossing over a given longitude" $ do
             let startTime = mkJulian 2021 8 9 0.0
@@ -251,6 +266,23 @@ spec = do
                 venusTrine = 265.5868455517535 - 120.0
             Right crossingJD <- moonCrossing venusTrine startTime
             getJulianDay crossingJD `shouldBe` expectedCrossing
+
+        describe "moonCrossingBetween" $ do
+          it "calculates the geocentric lunar crossing over a given longitude in an interval" $ do
+            let startTime = mkJulian 2021 8 9 0.0
+                endTime   = mkJulian 2021 8 10 0.0
+                -- 2021-Aug-09 06:56:14.57 UT
+                expectedCrossing = 2459435.7890575626
+                venusTrine = 265.5868455517535 - 120.0
+            Right crossingJD <- moonCrossingBetween venusTrine startTime endTime
+            getJulianDay crossingJD `shouldBe` expectedCrossing
+
+          it "knows when to give up when calculating the geocentric lunar crossing over a given longitude in an interval" $ do
+            let startTime = mkJulian 2021 8 9 0.0
+                endTime   = mkJulian 2021 8 9 2.0
+                venusTrine = 265.5868455517535 - 120.0
+            e <- moonCrossingBetween venusTrine startTime endTime
+            e `shouldSatisfy` isLeft
 
         describe "heliocentricCrossing" $
           it "calculates the heliocentric crossing of a planet over a given longitude" $ do

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -342,6 +342,16 @@ spec = do
           it "returns an error if a phase doesn't happen during an interval" $ do
             Left msg <- moonPhaseExactAt NewMoon (mkJulian 2021 9 8 0) (mkJulian 2021 9 10 0)
             msg `shouldBe` "swe_interpolate: not bracketed: 2459465.500802 - 2459467.500802"
+            
+          it "finds exactitude with tight lower bounds (edge cases for root finding)" $ do
+            let a1 = mkJulianDay STT 2459489.7091340744
+                a2 = succ a1
+                b1 = mkJulianDay STT 2459515.7091340744
+                b2 = succ b1
+            Right exactA <- moonPhaseExactAt WaningCrescent a1 a2
+            Right exactB <- moonPhaseExactAt LastQuarter b1 b2
+            getJulianDay exactA `shouldBe` 2459490.4836063166 
+            getJulianDay exactB `shouldBe` 2459516.3377326634
 
           it "finds all moments of exactitude for September 2021 (UTC)" $ do
             let _newMoon@(nmA, nmB) = (mkJulian 2021 9 7 0, mkJulian 2021 9 8 0)

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -254,9 +254,8 @@ spec = do
           it "knows when to give up calculating the geocentric solar crossing over a given longitude in an interval" $ do
             let startTime = mkJulian 2021 8 9 0.0
                 endTime   = mkJulian 2021 9 22 0.0
-            e <- sunCrossingBetween 180.0 startTime endTime
-            e `shouldSatisfy` isLeft
-            --e `shouldBe` "No crossing found in the specified interval"
+            Left e <- sunCrossingBetween 180.0 startTime endTime
+            e `shouldBe` "No crossing found in the specified interval."
 
         describe "moonCrossing" $
           it "calculates the geocentric lunar crossing over a given longitude" $ do
@@ -281,8 +280,8 @@ spec = do
             let startTime = mkJulian 2021 8 9 0.0
                 endTime   = mkJulian 2021 8 9 2.0
                 venusTrine = 265.5868455517535 - 120.0
-            e <- moonCrossingBetween venusTrine startTime endTime
-            e `shouldSatisfy` isLeft
+            Left e <- moonCrossingBetween venusTrine startTime endTime
+            e `shouldBe` "No crossing found in the specified interval."
 
         describe "heliocentricCrossing" $
           it "calculates the heliocentric crossing of a planet over a given longitude" $ do

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -209,9 +209,10 @@ spec = do
         Right (nextEclipseType, nextEclipseJD) <- nextSolarEclipseWhen [] SearchForward startTime
         Right nextEclipseLoc <- nextSolarEclipseWhere nextEclipseJD
         nextEclipseType `shouldBe` TotalSolarEclipse
-        julianNoon nextEclipseJD `shouldBe` julianNoon expectedEclipseDate 
+        julianNoon nextEclipseJD `shouldBe` julianNoon expectedEclipseDate
         -- somewhere in Antarctica
-        nextEclipseLoc `shouldBe` GeographicPosition {geoLat = -76.75422256653523, geoLng = -46.06809018915021}
+        geoLat nextEclipseLoc `shouldBeApprox` -76.75422256653523
+        geoLng nextEclipseLoc `shouldBeApprox` -46.06809018915021
 
     describe "lunar eclipses" $
       it "calculates the date of a lunar eclipse" $ do

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -319,6 +319,26 @@ spec = do
                 endTime   = mkJulian 2021 7 15 0.0
             Left msg <- directionChangeBetween Chiron startTime endTime
             msg `shouldBe` "swe_next_direction_change: no change within 1.000000 days"
+      
+      describe "bracketed geocentric crossings" $ do
+        describe "crossingBetween" $ do
+          it "finds the moment the moon crosses over a given longitude" $ do
+            let jd1 = mkJulianDay SUT1 2459449.5
+                jd2 = mkJulianDay SUT1 2459450.5
+                cross = 341.89809835262577
+                -- 2021-Aug-23 09:52:07.39 UTC 
+                expectedTime = 2459449.911196674
+            Right crossesAt <- crossingBetween Moon cross jd1 jd2
+            getJulianDay crossesAt `shouldBe` expectedTime
+
+          it "fails if the given times don't bracket the crossing" $ do
+            let jd1 = succ $ mkJulianDay SUT1 2459449.5
+                jd2 = succ $ mkJulianDay SUT1 2459450.5
+                cross = 341.89809835262577
+            Left msg <- crossingBetween Moon cross jd1 jd2
+            msg `shouldBe` "swe_interpolate: not bracketed: 2459450.500802 - 2459451.500802"
+
+
 
 
 {- For reference, here's an official test output from swetest.c as retrieved from the swetest page:

--- a/test/SwissEphemerisSpec.hs
+++ b/test/SwissEphemerisSpec.hs
@@ -339,6 +339,10 @@ spec = do
             msg `shouldBe` "swe_interpolate: not bracketed: 2459450.500802 - 2459451.500802"
 
         describe "bracketed moon phase exactitude" $ do
+          it "returns an error if a phase doesn't happen during an interval" $ do
+            Left msg <- moonPhaseExactAt NewMoon (mkJulian 2021 9 8 0) (mkJulian 2021 9 10 0)
+            msg `shouldBe` "swe_interpolate: not bracketed: 2459465.500802 - 2459467.500802"
+
           it "finds all moments of exactitude for September 2021 (UTC)" $ do
             let _newMoon@(nmA, nmB) = (mkJulian 2021 9 7 0, mkJulian 2021 9 8 0)
                 _waxingCrescent@(wcA, wcB) = (mkJulian 2021 9 10 0, mkJulian 2021 9 11 0)

--- a/test/TimeSpec.hs
+++ b/test/TimeSpec.hs
@@ -14,7 +14,6 @@ import Data.Maybe (isJust)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds, POSIXTime)
 import Arbitrary ()
 import Utils ( ephePath, mkUTC, civilTime )
-import qualified Debug.Trace as Debug
 
 withEphemeris :: IO ()
 withEphemeris = do
@@ -123,19 +122,11 @@ spec = beforeAll_ withEphemeris $ do
       prop "can roundtrip a UT1 Julian from any UTC" $
         forAll validTime $
           \time -> monadicIO $ do
-            jd' <- run (toJulianDay time :: (IO (ConversionResult JulianDayUT1)))
-            case getConversionResult jd' of
-              Left s -> Debug.traceM $ "ERROR: " <> s
-              Right _ -> pure ()
             Just jd <- run (toJulianDay time :: (IO (Maybe JulianDayUT1)))
             roundTripped <- run $ fromJulianDay jd
             let jdSeconds = utcTimeToPOSIXSeconds time
                 rtSeconds = utcTimeToPOSIXSeconds roundTripped
                 difference = abs $ subtract jdSeconds rtSeconds
-            if difference >= 1e-04 then
-              Debug.traceM $ "Exceeded diff: " <> show difference <> ": " <> show jd <> show time <> show roundTripped
-            else
-              pure ()
 
             assert $ difference < timeEpsilon
 
@@ -156,10 +147,7 @@ spec = beforeAll_ withEphemeris $ do
             let jdSeconds = utcTimeToPOSIXSeconds time
                 rtSeconds = utcTimeToPOSIXSeconds roundTripped
                 difference = abs $ subtract jdSeconds rtSeconds
-            if difference >= 1e-04 then
-              Debug.traceM $ "Exceeded diff: " <> show difference <> ": " <> show jd <> show time <> show roundTripped
-            else
-              pure ()
+  
             assert $ difference < timeEpsilon
 
   describe "delta time" $ do


### PR DESCRIPTION
- [x] Upgrade to the [latest swiss ephemeris, which introduces crossing fns](https://groups.io/g/swisseph/topic/new_release_2_10_02/84663960?p=,,,20,0,0,0::recentpostdate%2Fsticky,,,20,2,0,84663960)
- [x] Specialized phenomena fn (not applicable directly to moon phases, good for astronomy though)
- [x] Solar/lunar eclipses (global)
- [x] Solar/lunar crossings of a given longitude, heliocentric crossings of other bodies.
- [x] Fixes some rare test failures with the power of ~friendship~ reproducible quickcheck tests.
- [x] Adds functions to find when a planet changes direction. 
- [x] Adds function to find [one of the] exact moment[s] of a geocentric crossing in a [short] interval of time, using [Brent's method for root finding](https://en.wikipedia.org/wiki/Brent%27s_method) (*N.B* for longer intervals, which heliocentric/moon/sun crossings as we as direction changes can deal with, one would have to iterate in speed-adjusted steps to find crossing candidates _before_ attempting interpolation -- this can be added later, I already have a method for finding such candidates in my use case.)
- [x] Adds function to find the exact moment a given Moon phase occurs in an interval of time (known beforehand to contain the phase change.)

Fixes #30
Fixes #33 
Fixes #35 
Fixes #36

Some other references for root finding: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.brentq.html#scipy.optimize.brentq and https://www.gnu.org/software/gsl/doc/html/roots.html#root-bracketing-algorithms