### PR TITLE
Fix gravgroup

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,8 @@
 # Changelog for swiss-ephemeris
 
-## UPCOMING
+## v1.4.1.0 (2021-11-27)
 
+* Fix edge case in grav group
 * Export `utcToJulianDays`, to obtain a product of `(TT, UT1)` Julian Days from a `UTCTime` value --
   saves you one IO trip vs. getting them separately.
 * Support for GHC 9.2.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,11 +1,16 @@
 # Changelog for swiss-ephemeris
 
-## v1.4.1.0 (2021-11-27)
+
+# UPCOMING
 
 * Fix edge case in grav group: incorrect casting in the C code was causing
   planets that were too close to a sector boundary or another planet to be thrown
   back into the first sector.
 * Remove `cuspsToSectors`.
+
+
+## v1.4.1.0 (2021-11-27)
+
 * Export `utcToJulianDays`, to obtain a product of `(TT, UT1)` Julian Days from a `UTCTime` value --
   saves you one IO trip vs. getting them separately.
 * Support for GHC 9.2.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,10 @@
 
 ## v1.4.1.0 (2021-11-27)
 
-* Fix edge case in grav group
+* Fix edge case in grav group: incorrect casting in the C code was causing
+  planets that were too close to a sector boundary or another planet to be thrown
+  back into the first sector.
+* Remove `cuspsToSectors`.
 * Export `utcToJulianDays`, to obtain a product of `(TT, UT1)` Julian Days from a `UTCTime` value --
   saves you one IO trip vs. getting them separately.
 * Support for GHC 9.2.1

--- a/csrc/dgravgroup.c
+++ b/csrc/dgravgroup.c
@@ -65,7 +65,8 @@
 
 int grob_compare(const GROB *g1, const GROB *g2)
 {
-  return (int)(g1->pos - g2->pos);
+  // convert to centiseconds
+  return (int)(g1->pos * 360000) - (int)(g2->pos * 360000);
 }
 
 /*

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                swiss-ephemeris
-version:             1.4.1.0
+version:             1.4.2.0
 github:              "lfborjas/swiss-ephemeris"
 license:             AGPL-3
 author:              "Luis Borjas Reyes"

--- a/src/SwissEphemeris/ChartUtils.hs
+++ b/src/SwissEphemeris/ChartUtils.hs
@@ -244,7 +244,9 @@ gravGroupEasy' :: HasEclipticLongitude c =>
   -> [Double]
   -> Either String [PlanetGlyphInfo]
 gravGroupEasy' gravGroupF w ps s = do
-  glyphs <- gravGroupF (w/2,w/2) ps' (s' <> coda)
+  -- NOTE(luis) Only using `(++)` to please base <= 4.10,
+  -- I'm partial to treating all Semigroups uniformly!
+  glyphs <- gravGroupF (w/2,w/2) ps' (s' ++ coda)
   pure $ map (recenterGlyph s1) glyphs
   where
     coda =

--- a/src/SwissEphemeris/Internal.hs
+++ b/src/SwissEphemeris/Internal.hs
@@ -21,6 +21,7 @@ import Foreign.Storable
 -- in a 1-dimensional "longitude-only" manner.
 class Eq a => HasEclipticLongitude a where
   getEclipticLongitude :: a -> Double
+  setEclipticLongitude :: a -> Double -> a
 
 -- | All bodies for which a position can be calculated. Covers planets
 -- in the solar system, points between the Earth and the Moon, and
@@ -215,6 +216,7 @@ data EclipticPosition = EclipticPosition
 
 instance HasEclipticLongitude EclipticPosition where
   getEclipticLongitude = lng
+  setEclipticLongitude p l' = p{lng=l'}
 
 -- | Represents a point on Earth, with negative values
 -- for latitude meaning South, and negative values for longitude

--- a/src/SwissEphemeris/Precalculated.hs
+++ b/src/SwissEphemeris/Precalculated.hs
@@ -209,8 +209,9 @@ data EphemerisPosition a = EphemerisPosition
   }
   deriving (Eq, Show, Generic)
 
-instance (Real a, Eq a) => HasEclipticLongitude (EphemerisPosition a) where
+instance (Real a, Eq a, Fractional a) => HasEclipticLongitude (EphemerisPosition a) where
   getEclipticLongitude = realToFrac . epheLongitude
+  setEclipticLongitude p l' = p{epheLongitude = realToFrac l'}
 
 -- | The positions of all planets for a given time,
 -- plus ecliptic and nutation.

--- a/swiss-ephemeris.cabal
+++ b/swiss-ephemeris.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0feead7e44aba9915159eab5ab88bf44fc083266e7fbefe092fe08f1572f95b2
+-- hash: e7928c1b947cdfac890861bca07fa71244acadb0a156fc37ce416800d363e581
 
 name:           swiss-ephemeris
-version:        1.4.1.0
+version:        1.4.2.0
 synopsis:       Haskell bindings for the Swiss Ephemeris C library
 description:    Please see the README on GitHub at <https://github.com/lfborjas/swiss-ephemeris#readme>
 category:       Data, Astrology

--- a/test/ChartUtilsSpec.hs
+++ b/test/ChartUtilsSpec.hs
@@ -11,6 +11,7 @@ newtype Lng = Lng Double
 
 instance HasEclipticLongitude Lng where
   getEclipticLongitude (Lng d) = d
+  setEclipticLongitude (Lng _) d' = Lng d'
 
 examplePositions :: [(Planet, Lng)]
 examplePositions =
@@ -70,22 +71,32 @@ spec = do
     it "returns planets in corrected positions, when applicable" $ do
       let grouped = fromRight [] $ gravGroupEasy 5.0 examplePositions exampleCusps
           redux = sortBy sectorCompare grouped
-
       redux
-        `shouldBe` [ GlyphInfo {originalPosition = 22.78, glyphSize = (2.5, 2.5), placedPosition = 22.78, sectorNumber = 0, sequenceNumber = 4, levelNumber = 0, glyphScale = 1.0, extraData = Mars},
-                     GlyphInfo {originalPosition = 56.44, glyphSize = (2.5, 2.5), placedPosition = 56.44, sectorNumber = 1, sequenceNumber = 5, levelNumber = 0, glyphScale = 1.0, extraData = Jupiter},
-                     GlyphInfo {originalPosition = 93.53, glyphSize = (2.5, 2.5), placedPosition = 93.53, sectorNumber = 2, sequenceNumber = 12, levelNumber = 0, glyphScale = 1.0, extraData = Chiron},
-                     GlyphInfo {originalPosition = 176.41, glyphSize = (2.5, 2.5), placedPosition = 176.41, sectorNumber = 5, sequenceNumber = 11, levelNumber = 0, glyphScale = 1.0, extraData = MeanApog},
-                     GlyphInfo {originalPosition = 224.68, glyphSize = (2.5, 2.5), placedPosition = 224.68, sectorNumber = 7, sequenceNumber = 9, levelNumber = 0, glyphScale = 1.0, extraData = Pluto},
-                     GlyphInfo {originalPosition = 262.47, glyphSize = (2.5, 2.5), placedPosition = 258.6401159871351, sectorNumber = 8, sequenceNumber = 1, levelNumber = 0, glyphScale = 1.0, extraData = Moon},
-                     GlyphInfo {originalPosition = 264.04, glyphSize = (2.5, 2.5), placedPosition = 263.6401159871351, sectorNumber = 8, sequenceNumber = 3, levelNumber = 0, glyphScale = 1.0, extraData = Venus},
-                     GlyphInfo {originalPosition = 272.05, glyphSize = (2.5, 2.5), placedPosition = 268.6401159871351, sectorNumber = 8, sequenceNumber = 7, levelNumber = 0, glyphScale = 1.0, extraData = Uranus},
-                     GlyphInfo {originalPosition = 276.18, glyphSize = (2.5, 2.5), placedPosition = 273.6401159871351, sectorNumber = 8, sequenceNumber = 6, levelNumber = 0, glyphScale = 1.0, extraData = Saturn},
-                     GlyphInfo {originalPosition = 280.11, glyphSize = (2.5, 2.5), placedPosition = 278.6401159871351, sectorNumber = 8, sequenceNumber = 8, levelNumber = 0, glyphScale = 1.0, extraData = Neptune},
-                     GlyphInfo {originalPosition = 285.64, glyphSize = (2.5, 2.5), placedPosition = 285.64, sectorNumber = 9, sequenceNumber = 0, levelNumber = 0, glyphScale = 1.0, extraData = Sun},
-                     GlyphInfo {originalPosition = 304.31, glyphSize = (2.5, 2.5), placedPosition = 304.31, sectorNumber = 9, sequenceNumber = 2, levelNumber = 0, glyphScale = 1.0, extraData = Mercury},
-                     GlyphInfo {originalPosition = 337.52, glyphSize = (2.5, 2.5), placedPosition = 337.52, sectorNumber = 10, sequenceNumber = 10, levelNumber = 0, glyphScale = 1.0, extraData = MeanNode}
+        `shouldBe` [
+                    GlyphInfo {originalPosition = 224.68, glyphSize = (2.5, 2.5), placedPosition = 224.68, sectorNumber = 1, sequenceNumber = 9, levelNumber = 0, glyphScale = 1.0, extraData = Pluto},
+                    GlyphInfo {originalPosition = 262.47, glyphSize = (2.5, 2.5), placedPosition = 258.6401159871351, sectorNumber = 2, sequenceNumber = 1, levelNumber = 0, glyphScale = 1.0, extraData = Moon},
+                    GlyphInfo {originalPosition = 264.04, glyphSize = (2.5, 2.5), placedPosition = 263.6401159871351, sectorNumber = 2, sequenceNumber = 3, levelNumber = 0, glyphScale = 1.0, extraData = Venus},
+                    GlyphInfo {originalPosition = 272.05, glyphSize = (2.5, 2.5), placedPosition = 268.6401159871351, sectorNumber = 2, sequenceNumber = 7, levelNumber = 0, glyphScale = 1.0, extraData = Uranus},
+                    GlyphInfo {originalPosition = 276.18, glyphSize = (2.5, 2.5), placedPosition = 273.6401159871351, sectorNumber = 2, sequenceNumber = 6, levelNumber = 0, glyphScale = 1.0, extraData = Saturn},
+                    GlyphInfo {originalPosition = 280.11, glyphSize = (2.5, 2.5), placedPosition = 278.6401159871351, sectorNumber = 2, sequenceNumber = 8, levelNumber = 0, glyphScale = 1.0, extraData = Neptune},
+                    GlyphInfo {originalPosition = 285.64, glyphSize = (2.5, 2.5), placedPosition = 285.64, sectorNumber = 3, sequenceNumber = 0, levelNumber = 0, glyphScale = 1.0, extraData = Sun},
+                    GlyphInfo {originalPosition = 304.31, glyphSize = (2.5, 2.5), placedPosition = 304.31, sectorNumber = 3, sequenceNumber = 2, levelNumber = 0, glyphScale = 1.0, extraData = Mercury},
+                    GlyphInfo {originalPosition = 337.52, glyphSize = (2.5, 2.5), placedPosition = 337.52, sectorNumber = 4, sequenceNumber = 10, levelNumber = 0, glyphScale = 1.0, extraData = MeanNode},
+                    GlyphInfo {originalPosition = 22.779999999999973, glyphSize = (2.5, 2.5), placedPosition = 22.779999999999973, sectorNumber = 6, sequenceNumber = 4, levelNumber = 0, glyphScale = 1.0, extraData = Mars},
+                    GlyphInfo {originalPosition = 56.44, glyphSize = (2.5, 2.5), placedPosition = 56.44, sectorNumber = 7, sequenceNumber = 5, levelNumber = 0, glyphScale = 1.0, extraData = Jupiter},
+                    GlyphInfo {originalPosition = 93.53000000000003, glyphSize = (2.5, 2.5), placedPosition = 93.53000000000003, sectorNumber = 8, sequenceNumber = 12, levelNumber = 0, glyphScale = 1.0, extraData = Chiron},
+                    GlyphInfo {originalPosition = 176.41000000000008, glyphSize = (2.5, 2.5), placedPosition = 176.41000000000008, sectorNumber = 11, sequenceNumber = 11, levelNumber = 0, glyphScale = 1.0, extraData = MeanApog}
                    ]
+
+    it "can deal with sectors that jump 360" $ do
+      let planets = [(Uranus, Lng 41.685460865149885), (Chiron, Lng 8.560852515243027)]
+          sectors = [355.2817671250407, 26.407082565767553, 57.62582859633026]
+          grouped = fromRight [] $ gravGroupEasy 6 planets sectors
+      grouped `shouldBe` [
+                          GlyphInfo {originalPosition = 8.560852515243027, glyphSize = (3.0,3.0), placedPosition = 8.560852515243027, sectorNumber = 0, sequenceNumber = 1, levelNumber = 0, glyphScale = 1.0, extraData = Chiron},
+                          GlyphInfo {originalPosition = 41.68546086514988, glyphSize = (3.0,3.0), placedPosition = 41.68546086514988, sectorNumber = 1, sequenceNumber = 0, levelNumber = 0, glyphScale = 1.0, extraData = Uranus}
+                         ]
+
 
   describe "gravGroup2Easy" $ do
     it "accepts empty sectors" $ do

--- a/test/ChartUtilsSpec.hs
+++ b/test/ChartUtilsSpec.hs
@@ -93,8 +93,9 @@ spec = do
           sectors = []
           grouped = fromRight [] $ gravGroup2Easy 5.0 positions sectors True
       grouped
-        `shouldBe` [ GlyphInfo {originalPosition = 275.0, glyphSize = (2.5, 2.5), placedPosition = 272.25, sectorNumber = 0, sequenceNumber = 1, levelNumber = 0, glyphScale = 1.0, extraData = Venus},
-                     GlyphInfo {originalPosition = 274.5, glyphSize = (2.5, 2.5), placedPosition = 277.25, sectorNumber = 0, sequenceNumber = 0, levelNumber = 0, glyphScale = 1.0, extraData = Mars}
+        `shouldBe` [
+                     GlyphInfo {originalPosition = 274.5, glyphSize = (2.5, 2.5), placedPosition = 272.25, sectorNumber = 0, sequenceNumber = 0, levelNumber = 0, glyphScale = 1.0, extraData = Mars},
+                     GlyphInfo {originalPosition = 275.0, glyphSize = (2.5, 2.5), placedPosition = 277.25, sectorNumber = 0, sequenceNumber = 1, levelNumber = 0, glyphScale = 1.0, extraData = Venus}
                    ]
 
     it "shifts glyphs in narrow sectors to different levels, keeps the scale" $ do
@@ -103,8 +104,9 @@ spec = do
           sectors = [270.0, 274.0, 280.0]
           grouped = fromRight [] $ gravGroup2Easy 5.0 positions sectors True
       grouped
-        `shouldBe` [ GlyphInfo {originalPosition = 275.0, glyphSize = (2.5, 2.5), placedPosition = 276.5, sectorNumber = 1, sequenceNumber = 1, levelNumber = 0, glyphScale = 1.0, extraData = Venus},
-                     GlyphInfo {originalPosition = 274.5, glyphSize = (2.5, 2.5), placedPosition = 276.5, sectorNumber = 1, sequenceNumber = 0, levelNumber = 1, glyphScale = 1.0, extraData = Mars}
+        `shouldBe` [ 
+                     GlyphInfo {originalPosition = 274.5, glyphSize = (2.5, 2.5), placedPosition = 276.5, sectorNumber = 1, sequenceNumber = 0, levelNumber = 0, glyphScale = 1.0, extraData = Mars},
+                     GlyphInfo {originalPosition = 275.0, glyphSize = (2.5, 2.5), placedPosition = 276.5, sectorNumber = 1, sequenceNumber = 1, levelNumber = 1, glyphScale = 1.0, extraData = Venus}
                    ]
 
     it "returns planets in corrected positions, when applicable" $ do

--- a/test/ChartUtilsSpec.hs
+++ b/test/ChartUtilsSpec.hs
@@ -125,20 +125,30 @@ spec = do
           redux = sortBy sectorCompare grouped
 
       redux
-        `shouldBe` [ GlyphInfo {originalPosition = 22.78, glyphSize = (2.5, 2.5), placedPosition = 22.78, sectorNumber = 0, sequenceNumber = 4, levelNumber = 0, glyphScale = 1.0, extraData = Mars},
-                     GlyphInfo {originalPosition = 56.44, glyphSize = (2.5, 2.5), placedPosition = 56.44, sectorNumber = 1, sequenceNumber = 5, levelNumber = 0, glyphScale = 1.0, extraData = Jupiter},
-                     GlyphInfo {originalPosition = 93.53, glyphSize = (2.5, 2.5), placedPosition = 93.53, sectorNumber = 2, sequenceNumber = 12, levelNumber = 0, glyphScale = 1.0, extraData = Chiron},
-                     GlyphInfo {originalPosition = 176.41, glyphSize = (2.5, 2.5), placedPosition = 176.41, sectorNumber = 5, sequenceNumber = 11, levelNumber = 0, glyphScale = 1.0, extraData = MeanApog},
-                     GlyphInfo {originalPosition = 224.68, glyphSize = (2.5, 2.5), placedPosition = 224.68, sectorNumber = 7, sequenceNumber = 9, levelNumber = 0, glyphScale = 1.0, extraData = Pluto},
-                     GlyphInfo {originalPosition = 262.47, glyphSize = (2.5, 2.5), placedPosition = 258.6401159871351, sectorNumber = 8, sequenceNumber = 1, levelNumber = 0, glyphScale = 1.0, extraData = Moon},
-                     GlyphInfo {originalPosition = 264.04, glyphSize = (2.5, 2.5), placedPosition = 263.6401159871351, sectorNumber = 8, sequenceNumber = 3, levelNumber = 0, glyphScale = 1.0, extraData = Venus},
-                     GlyphInfo {originalPosition = 272.05, glyphSize = (2.5, 2.5), placedPosition = 268.6401159871351, sectorNumber = 8, sequenceNumber = 7, levelNumber = 0, glyphScale = 1.0, extraData = Uranus},
-                     GlyphInfo {originalPosition = 276.18, glyphSize = (2.5, 2.5), placedPosition = 273.6401159871351, sectorNumber = 8, sequenceNumber = 6, levelNumber = 0, glyphScale = 1.0, extraData = Saturn},
-                     GlyphInfo {originalPosition = 280.11, glyphSize = (2.5, 2.5), placedPosition = 278.6401159871351, sectorNumber = 8, sequenceNumber = 8, levelNumber = 0, glyphScale = 1.0, extraData = Neptune},
-                     GlyphInfo {originalPosition = 285.64, glyphSize = (2.5, 2.5), placedPosition = 285.64, sectorNumber = 9, sequenceNumber = 0, levelNumber = 0, glyphScale = 1.0, extraData = Sun},
-                     GlyphInfo {originalPosition = 304.31, glyphSize = (2.5, 2.5), placedPosition = 304.31, sectorNumber = 9, sequenceNumber = 2, levelNumber = 0, glyphScale = 1.0, extraData = Mercury},
-                     GlyphInfo {originalPosition = 337.52, glyphSize = (2.5, 2.5), placedPosition = 337.52, sectorNumber = 10, sequenceNumber = 10, levelNumber = 0, glyphScale = 1.0, extraData = MeanNode}
+        `shouldBe` [  
+                    GlyphInfo {originalPosition = 224.68, glyphSize = (2.5, 2.5), placedPosition = 224.68, sectorNumber = 1, sequenceNumber = 9, levelNumber = 0, glyphScale = 1.0, extraData = Pluto},
+                    GlyphInfo {originalPosition = 262.47, glyphSize = (2.5, 2.5), placedPosition = 258.6401159871351, sectorNumber = 2, sequenceNumber = 1, levelNumber = 0, glyphScale = 1.0, extraData = Moon},
+                    GlyphInfo {originalPosition = 264.04, glyphSize = (2.5, 2.5), placedPosition = 263.6401159871351, sectorNumber = 2, sequenceNumber = 3, levelNumber = 0, glyphScale = 1.0, extraData = Venus},
+                    GlyphInfo {originalPosition = 272.05, glyphSize = (2.5, 2.5), placedPosition = 268.6401159871351, sectorNumber = 2, sequenceNumber = 7, levelNumber = 0, glyphScale = 1.0, extraData = Uranus},
+                    GlyphInfo {originalPosition = 276.18, glyphSize = (2.5, 2.5), placedPosition = 273.6401159871351, sectorNumber = 2, sequenceNumber = 6, levelNumber = 0, glyphScale = 1.0, extraData = Saturn},
+                    GlyphInfo {originalPosition = 280.11, glyphSize = (2.5, 2.5), placedPosition = 278.6401159871351, sectorNumber = 2, sequenceNumber = 8, levelNumber = 0, glyphScale = 1.0, extraData = Neptune},
+                    GlyphInfo {originalPosition = 285.64, glyphSize = (2.5, 2.5), placedPosition = 285.64, sectorNumber = 3, sequenceNumber = 0, levelNumber = 0, glyphScale = 1.0, extraData = Sun},
+                    GlyphInfo {originalPosition = 304.31, glyphSize = (2.5, 2.5), placedPosition = 304.31, sectorNumber = 3, sequenceNumber = 2, levelNumber = 0, glyphScale = 1.0, extraData = Mercury},
+                    GlyphInfo {originalPosition = 337.52, glyphSize = (2.5, 2.5), placedPosition = 337.52, sectorNumber = 4, sequenceNumber = 10, levelNumber = 0, glyphScale = 1.0, extraData = MeanNode},
+                    GlyphInfo {originalPosition = 22.779999999999973, glyphSize = (2.5, 2.5), placedPosition = 22.779999999999973, sectorNumber = 6, sequenceNumber = 4, levelNumber = 0, glyphScale = 1.0, extraData = Mars},
+                    GlyphInfo {originalPosition = 56.44, glyphSize = (2.5, 2.5), placedPosition = 56.44, sectorNumber = 7, sequenceNumber = 5, levelNumber = 0, glyphScale = 1.0, extraData = Jupiter},
+                    GlyphInfo {originalPosition = 93.53000000000003, glyphSize = (2.5, 2.5), placedPosition = 93.53000000000003, sectorNumber = 8, sequenceNumber = 12, levelNumber = 0, glyphScale = 1.0, extraData = Chiron},
+                    GlyphInfo {originalPosition = 176.41000000000008, glyphSize = (2.5, 2.5), placedPosition = 176.41000000000008, sectorNumber = 11, sequenceNumber = 11, levelNumber = 0, glyphScale = 1.0, extraData = MeanApog}
                    ]
+
+    it "can deal with sectors that jump 360" $ do
+      let planets = [(Uranus, Lng 41.685460865149885), (Chiron, Lng 8.560852515243027)]
+          sectors = [355.2817671250407, 26.407082565767553, 57.62582859633026]
+          grouped = fromRight [] $ gravGroup2Easy 6 planets sectors False
+      grouped `shouldBe` [
+                          GlyphInfo {originalPosition = 8.560852515243027, glyphSize = (3.0,3.0), placedPosition = 8.560852515243027, sectorNumber = 0, sequenceNumber = 1, levelNumber = 0, glyphScale = 1.0, extraData = Chiron},
+                          GlyphInfo {originalPosition = 41.68546086514988, glyphSize = (3.0,3.0), placedPosition = 41.68546086514988, sectorNumber = 1, sequenceNumber = 0, levelNumber = 0, glyphScale = 1.0, extraData = Uranus}
+                         ]
 
 {-
 IDEAS FOR PROPS


### PR DESCRIPTION
* Fix casting error in `double`-based version of the C function for grav_group that was causing some objects to "float" out of their sector due to incorrect comparisons when sorting.
* Refactor the `*Easy` variants to avoid errors due to sectors that "jump" over 360 degrees .
* Remove now-inadvisable `cuspsToSectors` helper.